### PR TITLE
feat: delegation watcher/cache invalidator

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -27,6 +27,8 @@ import { createEmotionCache } from '@/styles/emotion'
 import { GATEWAY_URL } from '@/config/constants'
 import { AppRoutes } from '@/config/routes'
 import { useSafeSnapshot } from '@/hooks/useSafeSnapshot'
+import { useContractDelegateInvalidator } from '@/hooks/useContractDelegate'
+import { usePendingDelegations } from '@/hooks/usePendingDelegations'
 
 import '@/styles/globals.css'
 
@@ -37,11 +39,16 @@ const InitApp = (): null => {
   useInitWeb3()
   useInitWallet()
 
+  usePendingDelegations()
+
   // Populate caches
   useChains()
   useDelegatesFile()
   useIsTokenPaused()
   useSafeSnapshot()
+
+  // Invalidate caches
+  useContractDelegateInvalidator()
 
   return null
 }

--- a/src/components/Delegation/steps/ReviewDelegate/index.tsx
+++ b/src/components/Delegation/steps/ReviewDelegate/index.tsx
@@ -9,14 +9,15 @@ import { NavButtons } from '@/components/NavButtons'
 import { StepHeader } from '@/components/StepHeader'
 import { useWeb3 } from '@/hooks/useWeb3'
 import { setDelegate } from '@/services/delegate-registry'
-import { invalidateCacheAfterTx } from '@/services/QueryClient'
+import { setPendingDelegation } from '@/hooks/usePendingDelegations'
 import { useIsWrongChain } from '@/hooks/useIsWrongChain'
-import { CONTRACT_DELEGATE_QUERY_KEY } from '@/hooks/useContractDelegate'
+import { useIsSafeApp } from '@/hooks/useIsSafeApp'
 
 const ReviewDelegate = (): ReactElement => {
   const web3 = useWeb3()
   const isWrongChain = useIsWrongChain()
   const { stepperState, onBack, onNext } = useDelegationStepper()
+  const isSafeApp = useIsSafeApp()
 
   const [processing, setProcessing] = useState(false)
 
@@ -35,7 +36,11 @@ const ReviewDelegate = (): ReactElement => {
       return
     }
 
-    invalidateCacheAfterTx(CONTRACT_DELEGATE_QUERY_KEY, tx)
+    // Only EOA transactions can be pending
+    if (!isSafeApp) {
+      const address = await web3.getSigner().getAddress()
+      setPendingDelegation(address, tx)
+    }
 
     onNext()
   }

--- a/src/components/Delegation/steps/SuccessfulDelegation/index.tsx
+++ b/src/components/Delegation/steps/SuccessfulDelegation/index.tsx
@@ -2,10 +2,12 @@ import { Grid, Typography, Button } from '@mui/material'
 import type { ReactElement } from 'react'
 
 import { useDelegationStepper } from '@/components/Delegation'
+import { useIsSafeApp } from '@/hooks/useIsSafeApp'
 import SafeLogo from '@/public/images/safe-logo.svg'
 
 const SuccessfulDelegation = (): ReactElement => {
   const { onNext } = useDelegationStepper()
+  const isSafeApp = useIsSafeApp()
 
   return (
     <Grid container flexDirection="column" alignItems="center" pt={16} px={1} pb={22}>
@@ -15,7 +17,11 @@ const SuccessfulDelegation = (): ReactElement => {
         Transaction has been created
       </Typography>
 
-      <Typography mb={4}>You successfully delegated your voting power</Typography>
+      <Typography mb={4}>
+        {isSafeApp
+          ? 'You successfully started delegating! Once the transaction is signed and executed, your voting power will be delegated.'
+          : 'You successfully delegated your voting power!'}
+      </Typography>
 
       <Button variant="contained" color="primary" onClick={onNext}>
         Back to main

--- a/src/components/SelectedDelegate/index.tsx
+++ b/src/components/SelectedDelegate/index.tsx
@@ -1,10 +1,11 @@
-import { Button, Card, CardHeader, Typography } from '@mui/material'
+import { Button, Card, CardHeader, CircularProgress, Typography } from '@mui/material'
 import type { ReactElement } from 'react'
 
 import { DelegateAvatar } from '@/components/DelegateAvatar'
 import Avatar from '@/public/images/avatar.svg'
 import { InfoAlert } from '@/components/InfoAlert'
 import { shortenAddress } from '@/utils/addresses'
+import { useIsDelegationPending } from '@/hooks/usePendingDelegations'
 import type { Delegate } from '@/hooks/useDelegate'
 
 export const SelectedDelegate = ({
@@ -19,9 +20,17 @@ export const SelectedDelegate = ({
   hint?: boolean
 }): ReactElement => {
   const shortAddress = delegate ? shortenAddress(delegate.address) : undefined
+  const isDelegating = useIsDelegationPending()
 
-  const title = delegate ? ('name' in delegate ? delegate.name : shortAddress) : 'No delegate chosen'
-  const subheader = delegate ? ('ens' in delegate ? delegate.ens || shortAddress : shortAddress) : undefined
+  const title = isDelegating
+    ? 'Delegating...'
+    : delegate
+    ? 'name' in delegate
+      ? delegate.name
+      : shortAddress
+    : 'No delegate chosen'
+  const subheader =
+    delegate && !isDelegating ? ('ens' in delegate ? delegate.ens || shortAddress : shortAddress) : undefined
 
   return (
     <>
@@ -30,7 +39,7 @@ export const SelectedDelegate = ({
       </Typography>
       <Card variant="outlined" elevation={0}>
         <CardHeader
-          avatar={delegate ? <DelegateAvatar delegate={delegate} /> : <Avatar />}
+          avatar={isDelegating ? <CircularProgress /> : delegate ? <DelegateAvatar delegate={delegate} /> : <Avatar />}
           title={title}
           titleTypographyProps={{
             color: !delegate ? 'text.secondary' : undefined,
@@ -38,7 +47,7 @@ export const SelectedDelegate = ({
           subheader={subheader}
           action={
             onClick && (
-              <Button variant="contained" size="stretched" onClick={onClick} disabled={disabled}>
+              <Button variant="contained" size="stretched" onClick={onClick} disabled={isDelegating || disabled}>
                 {delegate ? 'Redelegate' : 'Delegate'}
               </Button>
             )

--- a/src/hooks/useContractDelegate.ts
+++ b/src/hooks/useContractDelegate.ts
@@ -1,12 +1,15 @@
+import { useEffect } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { formatBytes32String } from 'ethers/lib/utils'
+import { formatBytes32String, hexZeroPad } from 'ethers/lib/utils'
 import type { JsonRpcProvider } from '@ethersproject/providers'
 
-import { CHAIN_DELEGATE_ID, ZERO_ADDRESS } from '@/config/constants'
+import { CHAIN_DELEGATE_ID, DELEGATE_REGISTRY_ADDRESS, ZERO_ADDRESS } from '@/config/constants'
 import { useWeb3 } from '@/hooks/useWeb3'
-import { getDelegateRegistryContract } from '@/services/contracts/DelegateRegistry'
+import { getDelegateRegistryContract, getDelegateRegistryInterface } from '@/services/contracts/DelegateRegistry'
 import { useWallet } from '@/hooks/useWallet'
+import { getQueryClient } from '@/services/QueryClient'
 import type { FileDelegate } from '@/hooks/useDelegatesFile'
+import type { EventFilter } from '@ethersproject/abstract-provider'
 
 export type ContractDelegate = Pick<FileDelegate, 'address'>
 
@@ -40,7 +43,7 @@ export const _getContractDelegate = async (web3?: JsonRpcProvider): Promise<Cont
   }
 }
 
-export const CONTRACT_DELEGATE_QUERY_KEY = 'contractDelegate'
+const CONTRACT_DELEGATE_QUERY_KEY = 'contractDelegate'
 
 export const useContractDelegate = () => {
   const web3 = useWeb3()
@@ -51,4 +54,44 @@ export const useContractDelegate = () => {
     queryFn: () => _getContractDelegate(web3),
     enabled: !!web3,
   })
+}
+
+const delegateRegistryInterface = getDelegateRegistryInterface()
+const setDelegateEvent = delegateRegistryInterface.getEventTopic(
+  delegateRegistryInterface.events['SetDelegate(address,bytes32,address)'],
+)
+
+const queryClient = getQueryClient()
+
+export const useContractDelegateInvalidator = () => {
+  const web3 = useWeb3()
+
+  useEffect(() => {
+    if (!web3) {
+      return
+    }
+
+    let filter: EventFilter
+
+    ;(async () => {
+      const signer = web3.getSigner()
+
+      const address = await signer.getAddress()
+      const chainId = await signer.getChainId()
+
+      const delegateId = CHAIN_DELEGATE_ID[chainId]
+
+      filter = {
+        address: DELEGATE_REGISTRY_ADDRESS,
+        // Each topic has to be 32 bytes
+        topics: [setDelegateEvent, hexZeroPad(address, 32), formatBytes32String(delegateId)],
+      }
+
+      web3.on(filter, () => queryClient.invalidateQueries({ queryKey: [CONTRACT_DELEGATE_QUERY_KEY] }))
+    })()
+
+    return () => {
+      web3.off(filter)
+    }
+  }, [web3])
 }

--- a/src/hooks/usePendingDelegations.ts
+++ b/src/hooks/usePendingDelegations.ts
@@ -1,0 +1,61 @@
+import { useEffect } from 'react'
+import type { ContractTransaction } from 'ethers/lib/ethers'
+
+import { ExternalStore } from '@/services/ExternalStore'
+import { useWallet } from './useWallet'
+import { didRevert } from '@/utils/transactions'
+
+// Note: only EOA transactions can be pending
+
+const delegateTxsStore = new ExternalStore<{ [providerAddress: string]: ContractTransaction }>()
+
+export const setPendingDelegation = (providerAddress: string, tx: ContractTransaction) => {
+  delegateTxsStore.setStore((delegations) => ({
+    ...delegations,
+    [providerAddress]: tx,
+  }))
+}
+
+const removePendingDelegation = (providerAddress: string) => {
+  delegateTxsStore.setStore(({ [providerAddress]: _, ...rest } = {}) => rest)
+}
+
+export const usePendingDelegations = () => {
+  const delegations = delegateTxsStore.useStore()
+  const wallet = useWallet()
+
+  useEffect(() => {
+    let isMounted = true
+
+    if (!wallet?.address) {
+      return
+    }
+
+    delegations?.[wallet.address]
+      ?.wait()
+      .then((receipt) => {
+        if (didRevert(receipt)) {
+          console.error('Delegation reverted', receipt)
+        }
+      })
+      .catch((err) => {
+        console.error('Delegation failed', err)
+      })
+      .finally(() => {
+        if (isMounted) {
+          removePendingDelegation(wallet.address)
+        }
+      })
+
+    return () => {
+      isMounted = false
+    }
+  }, [wallet?.address, delegations])
+}
+
+export const useIsDelegationPending = (): boolean => {
+  const delegations = delegateTxsStore.useStore()
+  const wallet = useWallet()
+
+  return wallet?.address ? !!delegations?.[wallet.address] : false
+}

--- a/src/services/QueryClient.ts
+++ b/src/services/QueryClient.ts
@@ -1,42 +1,7 @@
 import { QueryClient } from '@tanstack/react-query'
-import type { ContractTransaction } from '@ethersproject/contracts'
-
-import { didRevert } from '@/utils/transactions'
 
 const _queryClient = new QueryClient()
 
 export const getQueryClient = () => {
   return _queryClient
-}
-
-let txWatchers: { [QUERY_KEY: string]: Promise<void>[] } = {}
-
-/**
- * Waits for a transaction to be mined and invalidates the cache for the given query key.
- * We cannot await a transaction receipt directly because Safe transactions that require
- * multiple confirmations would block the UI.
- *
- * @param queryKey react-query cache key
- * @param tx ethers contract transaction
- */
-
-export const invalidateCacheAfterTx = (queryKey: string, tx: ContractTransaction): void => {
-  const txWatcher = tx
-    .wait()
-    .then((receipt) => {
-      if (didRevert(receipt)) {
-        console.error(`${queryKey} transaction reverted`, receipt)
-      } else {
-        _queryClient.invalidateQueries({ queryKey: [queryKey] })
-      }
-    })
-    .catch((e) => {
-      console.error(`${queryKey} transaction failed`, e)
-    })
-
-  txWatchers[queryKey] ??= []
-
-  // We do not replace previous "watchers", even for the same address as they
-  // may resolve before one another
-  txWatchers[queryKey].push(txWatcher)
 }


### PR DESCRIPTION
## What it solves

Clearer information regarding `setDelegate` calls.

## How this PR fixes it

- Dynamic delegation feedback.
  - Explanatory text for Safe Apps regarding the required confirmations.
  - `setDelegate` transaction watcher for EOAs that shows a loading spinner.
- Cache invalidation based on `setDelegate` events.