### PR TITLE
fix: only check wallet if it is present

### DIFF
--- a/src/components/Intro/index.tsx
+++ b/src/components/Intro/index.tsx
@@ -41,11 +41,8 @@ export const Intro = (): ReactElement => {
   const canDelegate = !isDelegating && !!data?.votingPower && BigNumber.from(data.votingPower).gt(0) && !isWrongChain
 
   const onClick = (route: (typeof AppRoutes)[keyof typeof AppRoutes]) => async () => {
-    if (!wallet) {
-      return
-    }
     // Safe is connected via WC
-    if (await isSafe(wallet)) {
+    if (wallet && (await isSafe(wallet))) {
       window.open(getGovernanceAppSafeAppUrl(chainId, wallet.address), '_blank')?.focus()
     } else {
       router.push(route)


### PR DESCRIPTION
## What it solves

Impossible navigation as a Safe App

## How this PR fixes it

If a `wallet` is not present (currently using the App as a Safe App), navigation is now possible.

## How to test it

Open the App as a Safe App and click either "Claim tokens" or "Redelegate". Observe navigation to the relevant route.

Note: ensure that connecting a Safe to the DApp via WC still opens the Safe App in a new window.