### PR TITLE
fix: rename "Safe {DAO}" to "Safe{DAO}"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Safe {DAO} Governance
+# Safe{DAO} Governance
 
-The portal to Safe {DAO} governance, voting power delegation and allocation claiming.
+The portal to Safe{DAO} governance, voting power delegation and allocation claiming.
 
 ## Environments
 

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "short_name": "safe-dao-governance-app",
-  "name": "Safe {DAO} Governance",
-  "description": "The portal to Safe {DAO} governance, voting power delegation and allocation claiming.",
+  "name": "Safe{DAO} Governance",
+  "description": "The portal to Safe{DAO} governance, voting power delegation and allocation claiming.",
   "icons": [
     {
       "src": "/images/app-logo.svg",

--- a/src/components/Claim/steps/SuccessfulClaim/index.tsx
+++ b/src/components/Claim/steps/SuccessfulClaim/index.tsx
@@ -17,7 +17,7 @@ const SuccessfulClaim = (): ReactElement => {
 
   return (
     <Grid container flexDirection="column" alignItems="center" pt={16} px={12} pb={22} sx={{ backgroundColor }}>
-      <SafeLogo alt="Safe {DAO} logo" width={125} height={110} />
+      <SafeLogo alt="Safe{DAO} logo" width={125} height={110} />
 
       <Typography variant="h1" mt={6} mb={2} color={textColor}>
         Congrats!

--- a/src/components/ConnectWallet/index.tsx
+++ b/src/components/ConnectWallet/index.tsx
@@ -35,7 +35,7 @@ export const ConnectWallet = (): ReactElement => {
 
   return (
     <Grid container flexDirection="column" alignItems="center" px={1} py={6}>
-      <SafeLogo alt="Safe {DAO} logo" width={125} height={110} />
+      <SafeLogo alt="Safe{DAO} logo" width={125} height={110} />
 
       <Typography variant="h1" m={5} mb={6} textAlign="center">
         Welcome to the next generation of digital ownership

--- a/src/components/DashboardWidgets/ClaimingWidget.tsx
+++ b/src/components/DashboardWidgets/ClaimingWidget.tsx
@@ -49,7 +49,7 @@ const CtaWidget = (): ReactElement => {
       <br />
       <Subtitle>
         Help us unlock ownership for everyone by joining the discussions on the{' '}
-        <ExternalLink href={FORUM_URL}>SafeDAO Forum</ExternalLink> and our{' '}
+        <ExternalLink href={FORUM_URL}>Safe{`{DAO}`} Forum</ExternalLink> and our{' '}
         <ExternalLink href={DISCORD_URL}>Discord</ExternalLink>.
       </Subtitle>
     </div>

--- a/src/components/DashboardWidgets/SnapshotWidget.tsx
+++ b/src/components/DashboardWidgets/SnapshotWidget.tsx
@@ -95,7 +95,7 @@ export const SnapshotWidget = (): ReactElement => {
             View all
           </ExternalLink>
           <ExternalLink href={FORUM_URL} variant="subtitle1" textAlign="center">
-            SafeDAO Forum
+            Safe{`{DAO}`} Forum
           </ExternalLink>
         </Box>
       </Box>

--- a/src/components/DashboardWidgets/__tests__/SnapshotWidget.test.ts
+++ b/src/components/DashboardWidgets/__tests__/SnapshotWidget.test.ts
@@ -3,7 +3,7 @@ import { _getProposalNumber, _getProposalTitle } from '../SnapshotWidget'
 describe('SnapshotWidget', () => {
   describe('getProposalNumber', () => {
     it('should return proposal numbers from differently formatted titles', () => {
-      const proposalNumber = _getProposalNumber('SEP #1: SafeDAO Participation Agreement')
+      const proposalNumber = _getProposalNumber('SEP #1: Safe{DAO} Participation Agreement')
       expect(proposalNumber).toBe('SEP #1')
 
       const proposalNumber2 = _getProposalNumber(
@@ -14,8 +14,8 @@ describe('SnapshotWidget', () => {
   })
   describe('getProposalTitle', () => {
     it('should strip differently formatted proposal numbers', () => {
-      const proposalNumber = _getProposalTitle('SEP #1: SafeDAO Participation Agreement')
-      expect(proposalNumber).toBe('SafeDAO Participation Agreement')
+      const proposalNumber = _getProposalTitle('SEP #1: Safe{DAO} Participation Agreement')
+      expect(proposalNumber).toBe('Safe{DAO} Participation Agreement')
 
       const proposalNumber2 = _getProposalTitle(
         '[SEP #2] Community Initiative To Unpause Token Contract (Enabling Transferability)',

--- a/src/components/Delegation/steps/SuccessfulDelegation/index.tsx
+++ b/src/components/Delegation/steps/SuccessfulDelegation/index.tsx
@@ -11,7 +11,7 @@ const SuccessfulDelegation = (): ReactElement => {
 
   return (
     <Grid container flexDirection="column" alignItems="center" pt={16} px={1} pb={22}>
-      <SafeLogo alt="Safe {DAO} logo" width={125} height={110} />
+      <SafeLogo alt="Safe{DAO} logo" width={125} height={110} />
 
       <Typography variant="h1" mt={6} mb={2}>
         Transaction has been created

--- a/src/components/EducationSeries/steps/Disclaimer/index.tsx
+++ b/src/components/EducationSeries/steps/Disclaimer/index.tsx
@@ -15,7 +15,7 @@ const Disclaimer = (): ReactElement => {
       </Grid>
 
       <Typography mb={3}>
-        This App is for our community to encourage Safe ecosystem contributors and users to unlock Safe {`{DAO}`}{' '}
+        This App is for our community to encourage Safe ecosystem contributors and users to unlock Safe{`{DAO}`}{' '}
         governance.
         <br />
         <br />
@@ -27,7 +27,7 @@ const Disclaimer = (): ReactElement => {
         By accessing this app, you represent and warrant
         <br />- that you are of legal age and that you will comply with any laws applicable to you and not engage in any
         illegal activities;
-        <br />- that you are claiming Safe tokens to participate in the Safe {`{DAO}`} governance process and that they
+        <br />- that you are claiming Safe tokens to participate in the Safe{`{DAO}`} governance process and that they
         do not represent consideration for past or future services;
         <br />- that you, the country you are a resident of and your wallet address is not on any sanctions lists
         maintained by the United Nations, Switzerland, the EU, UK or the US;

--- a/src/components/EducationSeries/steps/Distribution/index.tsx
+++ b/src/components/EducationSeries/steps/Distribution/index.tsx
@@ -50,7 +50,7 @@ const Distribution = (): ReactElement => {
             </Typography>
           </Box>
           <Typography>
-            40% Safe {`{DAO}`} Treasury
+            40% Safe{`{DAO}`} Treasury
             <br />
             15% GnosisDAO Treasury
             <br />

--- a/src/components/EducationSeries/steps/SafeDao/index.tsx
+++ b/src/components/EducationSeries/steps/SafeDao/index.tsx
@@ -33,7 +33,7 @@ const SafeDao = (): ReactElement => {
       </Grid>
 
       <Typography mb={3}>
-        Safe {`{DAO}`} aims to foster a vibrant ecosystem of applications and wallets leveraging Safe smart contract
+        Safe{`{DAO}`} aims to foster a vibrant ecosystem of applications and wallets leveraging Safe smart contract
         accounts. This will be achieved through data-backed discussions, grants, ecosystem investments, as well as
         providing developer tools and infrastructure.
       </Typography>
@@ -44,7 +44,7 @@ const SafeDao = (): ReactElement => {
 
       <Box display="flex" flexDirection="column" gap={3} mb={3.5}>
         <Point>
-          Discuss Safe {`{DAO}`} improvements - post topics and discuss in our{' '}
+          Discuss Safe{`{DAO}`} improvements - post topics and discuss in our{' '}
           <ExternalLink href={FORUM_URL}>Forum</ExternalLink>
         </Point>
 

--- a/src/components/EducationSeries/steps/SafeDao/index.tsx
+++ b/src/components/EducationSeries/steps/SafeDao/index.tsx
@@ -29,7 +29,7 @@ const SafeDao = (): ReactElement => {
   return (
     <Grid container px={6} pt={5} pb={4}>
       <Grid item xs={12} mb={3}>
-        <StepHeader title="Navigating Safe {DAO}" />
+        <StepHeader title="Navigating Safe{DAO}" />
       </Grid>
 
       <Typography mb={3}>

--- a/src/components/OverviewLinks/index.tsx
+++ b/src/components/OverviewLinks/index.tsx
@@ -71,7 +71,7 @@ export const OverviewLinks = (): ReactElement => {
       </Grid>
       <Grid item xs container>
         <Grid item xs={12} pb={{ sm: 1, xs: 2 }}>
-          <ExternalLinkCard href={FORUM_URL} header="Discuss" title="Safe {DAO} forum" />
+          <ExternalLinkCard href={FORUM_URL} header="Discuss" title="Safe{DAO} forum" />
         </Grid>
         <Grid item xs={12}>
           <ExternalLinkCard href={snapshotUrl} header="Vote" title="Snapshot" />

--- a/src/components/OverviewLinks/index.tsx
+++ b/src/components/OverviewLinks/index.tsx
@@ -30,7 +30,7 @@ const SafeDaoCard = () => {
         <Typography variant="h3" fontWeight={700}>
           What is
           <br />
-          Safe {`{DAO}`}?
+          Safe{`{DAO}`}?
         </Typography>
         <Link href={AppRoutes.safedao} component={NextLink} ref={linkRef}>
           Learn more


### PR DESCRIPTION
## What it solves

Aligns the Safe{DAO} labelling.

## How this PR fixes it

All instances of  "Safe {DAO}" have been renamed to "Safe{DAO}".

## How to test it

Open the App and observe all instances of "Safe{DAO}" have no spaces.