### PR TITLE
fix: use Safe `chainId` for claiming widget

### DIFF
--- a/src/components/DashboardWidgets/ClaimingWidget.tsx
+++ b/src/components/DashboardWidgets/ClaimingWidget.tsx
@@ -16,7 +16,6 @@ import { useDelegate } from '@/hooks/useDelegate'
 import { useSafeTokenAllocation } from '@/hooks/useSafeTokenAllocation'
 import { SelectedDelegate } from '@/components/SelectedDelegate'
 import { formatAmount } from '@/utils/formatters'
-import { useChainId } from '@/hooks/useChainId'
 
 import css from './styles.module.css'
 
@@ -78,7 +77,6 @@ const VotingPowerWidget = (): ReactElement => {
   const { safe } = useSafeAppsSDK()
   const delegate = useDelegate()
   const { data } = useSafeTokenAllocation()
-  const chainId = useChainId()
 
   const totalClaimed = data?.vestingData?.reduce((acc, { amountClaimed }) => {
     return acc.add(amountClaimed)
@@ -86,7 +84,7 @@ const VotingPowerWidget = (): ReactElement => {
 
   const hasUnredeemedAllocation = data?.vestingData?.some(({ isExpired, isRedeemed }) => !isExpired && !isRedeemed)
 
-  const claimingSafeAppUrl = getGovernanceAppSafeAppUrl(chainId, safe.safeAddress)
+  const claimingSafeAppUrl = getGovernanceAppSafeAppUrl(safe.chainId, safe.safeAddress)
 
   return (
     <>


### PR DESCRIPTION
## What it solves

Invalid Safe address in claiming widget link.

## How this PR fixes it

The `chainId` from the Safe is used.

## How to test it

1. Exchange the widget link with this deployment.
2. Connect wallet to non-Goerli network.
3. Open Safe with allocation.
4. Click link on claiming widget and observe it open on Goerli.