### PR TITLE
refactor: create custom cache invalidators

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -25,8 +25,8 @@ import { createEmotionCache } from '@/styles/emotion'
 import { GATEWAY_URL } from '@/config/constants'
 import { AppRoutes } from '@/config/routes'
 import { useSafeSnapshot } from '@/hooks/useSafeSnapshot'
-import { useContractDelegateInvalidator } from '@/hooks/useContractDelegate'
-import { useSafeTokenTransferInvalidator } from '@/hooks/useSafeTokenAllocation'
+import { useContractDelegateInvalidator } from '@/hooks/useContractDelegateInvalidator'
+import { useSafeTokenAllocationInvalidator } from '@/hooks/useSafeTokenAllocationInvalidator'
 import { usePendingDelegations } from '@/hooks/usePendingDelegations'
 
 import '@/styles/globals.css'
@@ -35,19 +35,9 @@ const isDashboard = (pathname: string): boolean => {
   return pathname === AppRoutes.widgets
 }
 
-/**
- * TODO: Migrate invalidators to use custom timeouts instead of
- * ethers' `on` function as they do not allow custom timeouts
- * and otherwise increase RPC calls substantially.
- *
- * {@link} useContractDelegateInvalidator
- * {@link} useSafeTokenTransferInvalidator
- *
- * @see https://docs.ethers.org/v5/concepts/events/
- */
 const Invalidators = (): null => {
   useContractDelegateInvalidator()
-  useSafeTokenTransferInvalidator()
+  useSafeTokenAllocationInvalidator()
 
   return null
 }

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -5,6 +5,8 @@ export const INFURA_TOKEN = process.env.NEXT_PUBLIC_INFURA_TOKEN || ''
 export const LS_NAMESPACE = 'SAFE__'
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
+export const POLLING_INTERVAL = 30_000
+
 // Wallets
 export const WC_BRIDGE = process.env.NEXT_PUBLIC_WC_BRIDGE || ''
 export const TREZOR_APP_URL = 'app.safe.global'

--- a/src/hooks/__tests__/useContractDelegateInvalidator.test.ts
+++ b/src/hooks/__tests__/useContractDelegateInvalidator.test.ts
@@ -1,0 +1,164 @@
+import { hexZeroPad } from 'ethers/lib/utils'
+import { act, renderHook, waitFor } from '@testing-library/react'
+
+import * as useWeb3Hook from '@/hooks/useWeb3'
+import * as useContractDelegateHook from '@/hooks/useContractDelegate'
+import * as DelegateRegistry from '@/services/contracts/DelegateRegistry'
+import { useContractDelegateInvalidator } from '@/hooks/useContractDelegateInvalidator'
+
+jest.mock('@/hooks/useWeb3', () => ({
+  useWeb3: jest.fn(),
+}))
+
+jest.mock('@/hooks/useContractDelegate', () => ({
+  useContractDelegate: jest.fn(),
+}))
+
+jest.mock('@/services/contracts/DelegateRegistry', () => ({
+  getDelegateRegistryContract: jest.fn(),
+}))
+
+describe('useContractDelegateInvalidator', () => {
+  const CHAIN_ID = 5
+  const MOCK_ADDRESS = hexZeroPad('0x1', 20)
+
+  const BASE_BLOCK_NUMBER = 0
+
+  const MOCK_FILTER = 'mockFilter'
+
+  jest.useFakeTimers()
+
+  let mockQueryFilter: jest.Mock
+  let mockMutate: jest.Mock
+
+  let setIntervalSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    jest.spyOn(useWeb3Hook, 'useWeb3').mockImplementation(
+      jest.fn(() => ({
+        getSigner: jest.fn(() => ({
+          getChainId: () => Promise.resolve(CHAIN_ID),
+          getAddress: () => Promise.resolve(MOCK_ADDRESS),
+        })),
+        getBlockNumber: () => Promise.resolve(BASE_BLOCK_NUMBER),
+      })) as unknown as typeof useWeb3Hook.useWeb3,
+    )
+
+    mockMutate = jest.fn()
+    jest.spyOn(useContractDelegateHook, 'useContractDelegate').mockImplementation(
+      jest.fn(() => ({
+        mutate: mockMutate,
+      })) as unknown as typeof useContractDelegateHook.useContractDelegate,
+    )
+
+    // TODO: Can be made more robust by mocking signer instead of this
+    mockQueryFilter = jest.fn()
+    jest.spyOn(DelegateRegistry, 'getDelegateRegistryContract').mockImplementation(
+      jest.fn(() => ({
+        queryFilter: mockQueryFilter,
+        filters: {
+          SetDelegate: jest.fn(() => MOCK_FILTER),
+        },
+      })) as unknown as typeof DelegateRegistry.getDelegateRegistryContract,
+    )
+
+    setIntervalSpy = jest.spyOn(global, 'setInterval')
+  })
+
+  it('should invalidate the cache if the filter returns event(s)', async () => {
+    mockQueryFilter.mockResolvedValue([{ blockNumber: BASE_BLOCK_NUMBER + 1 }])
+
+    renderHook(() => useContractDelegateInvalidator())
+
+    expect(mockQueryFilter).not.toHaveBeenCalled()
+    expect(mockMutate).not.toHaveBeenCalled()
+
+    await waitFor(() => {
+      expect(setIntervalSpy).toHaveBeenCalledTimes(1)
+    })
+
+    // First interval
+    act(() => {
+      jest.runOnlyPendingTimers()
+    })
+
+    expect(mockQueryFilter).toHaveBeenCalledTimes(1)
+    expect(mockQueryFilter).toHaveBeenCalledWith(MOCK_FILTER, 0, 'latest')
+
+    // Invalidate cache
+    await waitFor(() => {
+      expect(mockMutate).toBeCalledTimes(1)
+    })
+  })
+
+  it('should not invalidate the cache if the filter returns no event(s)', async () => {
+    mockQueryFilter.mockResolvedValue([])
+
+    renderHook(() => useContractDelegateInvalidator())
+
+    expect(mockQueryFilter).not.toHaveBeenCalled()
+    expect(mockMutate).not.toHaveBeenCalled()
+
+    await waitFor(() => {
+      expect(setIntervalSpy).toHaveBeenCalledTimes(1)
+    })
+
+    // First interval
+    act(() => {
+      jest.runOnlyPendingTimers()
+    })
+
+    expect(mockQueryFilter).toBeCalledTimes(1)
+    expect(mockQueryFilter).toHaveBeenCalledWith(MOCK_FILTER, 0, 'latest')
+
+    // Ensure mutation could have happened
+    await Promise.resolve()
+
+    // Don't invalidate cache
+    expect(mockMutate).not.toHaveBeenCalled()
+  })
+
+  it('should not invalidate the cache if the subsequent filter poll returns no event(s)', async () => {
+    mockQueryFilter.mockResolvedValue([{ blockNumber: BASE_BLOCK_NUMBER + 1 }])
+
+    renderHook(() => useContractDelegateInvalidator())
+
+    expect(mockQueryFilter).not.toHaveBeenCalled()
+    expect(mockMutate).not.toHaveBeenCalled()
+
+    await waitFor(() => {
+      expect(setIntervalSpy).toHaveBeenCalledTimes(1)
+    })
+
+    // First interval
+    act(() => {
+      jest.runOnlyPendingTimers()
+    })
+
+    expect(mockQueryFilter).toBeCalledTimes(1)
+    expect(mockQueryFilter).toHaveBeenCalledWith(MOCK_FILTER, BASE_BLOCK_NUMBER, 'latest')
+
+    // Invalidate cache
+    await waitFor(() => {
+      expect(mockMutate).toBeCalledTimes(1)
+    })
+
+    mockQueryFilter.mockResolvedValue([])
+
+    // Second interval
+    act(() => {
+      jest.runOnlyPendingTimers()
+    })
+
+    expect(mockQueryFilter).toBeCalledTimes(2)
+    expect(mockQueryFilter).toHaveBeenCalledWith(MOCK_FILTER, BASE_BLOCK_NUMBER + 1, 'latest')
+
+    // Ensure second mutation could have happened
+    await Promise.resolve()
+
+    // Don't invalidate cache
+    expect(mockMutate).toBeCalledTimes(1)
+  })
+})

--- a/src/hooks/__tests__/useSafeTokenAllocationInvalidator.test.ts
+++ b/src/hooks/__tests__/useSafeTokenAllocationInvalidator.test.ts
@@ -1,0 +1,253 @@
+import { hexZeroPad } from 'ethers/lib/utils'
+import { act, renderHook, waitFor } from '@testing-library/react'
+
+import * as useWeb3Hook from '@/hooks/useWeb3'
+import * as useSafeTokenAllocationHook from '@/hooks/useSafeTokenAllocation'
+import * as SafeToken from '@/services/contracts/SafeToken'
+import { useSafeTokenAllocationInvalidator } from '@/hooks/useSafeTokenAllocationInvalidator'
+
+jest.mock('@/hooks/useWeb3', () => ({
+  useWeb3: jest.fn(),
+}))
+
+jest.mock('@/hooks/useSafeTokenAllocation', () => ({
+  useSafeTokenAllocation: jest.fn(),
+}))
+
+jest.mock('@/services/contracts/SafeToken', () => ({
+  getSafeTokenContract: jest.fn(),
+}))
+
+describe('useSafeTokenAllocationInvalidator', () => {
+  const CHAIN_ID = 5
+  const MOCK_ADDRESS = hexZeroPad('0x1', 20)
+
+  const BASE_BLOCK_NUMBER = 0
+
+  const MOCK_TO_FILTER = 'mockToFilter'
+  const MOCK_FROM_FILTER = 'mockFromFilter'
+
+  jest.useFakeTimers()
+
+  let mockQueryFilter: jest.Mock
+  let mockMutate: jest.Mock
+
+  let setIntervalSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    jest.spyOn(useWeb3Hook, 'useWeb3').mockImplementation(
+      jest.fn(() => ({
+        getSigner: jest.fn(() => ({
+          getChainId: () => Promise.resolve(CHAIN_ID),
+          getAddress: () => Promise.resolve(MOCK_ADDRESS),
+        })),
+        getBlockNumber: () => Promise.resolve(BASE_BLOCK_NUMBER),
+      })) as unknown as typeof useWeb3Hook.useWeb3,
+    )
+
+    mockMutate = jest.fn()
+    jest.spyOn(useSafeTokenAllocationHook, 'useSafeTokenAllocation').mockImplementation(
+      jest.fn(() => ({
+        mutate: mockMutate,
+      })) as unknown as typeof useSafeTokenAllocationHook.useSafeTokenAllocation,
+    )
+
+    // TODO: Can be made more robust by mocking signer instead of this
+    mockQueryFilter = jest.fn()
+    jest.spyOn(SafeToken, 'getSafeTokenContract').mockImplementation(
+      jest.fn(() => ({
+        queryFilter: mockQueryFilter,
+        filters: {
+          Transfer: jest.fn((signerAddress) => {
+            return signerAddress ? MOCK_FROM_FILTER : MOCK_TO_FILTER
+          }),
+        },
+      })) as unknown as typeof SafeToken.getSafeTokenContract,
+    )
+
+    setIntervalSpy = jest.spyOn(global, 'setInterval')
+  })
+
+  it('should invalidate the cache if the to transfer filter returns new event(s)', async () => {
+    mockQueryFilter.mockImplementation(
+      jest.fn((filter) => {
+        return filter === MOCK_TO_FILTER
+          ? Promise.resolve([{ blockNumber: BASE_BLOCK_NUMBER + 1 }])
+          : Promise.resolve([])
+      }),
+    )
+
+    renderHook(() => useSafeTokenAllocationInvalidator())
+
+    expect(mockQueryFilter).not.toHaveBeenCalled()
+    expect(mockMutate).not.toHaveBeenCalled()
+
+    await waitFor(() => {
+      expect(setIntervalSpy).toHaveBeenCalledTimes(1)
+    })
+
+    // First interval
+    act(() => {
+      jest.runOnlyPendingTimers()
+    })
+
+    expect(mockQueryFilter).toHaveBeenCalledTimes(2)
+    expect(mockQueryFilter.mock.calls).toEqual([
+      [MOCK_FROM_FILTER, BASE_BLOCK_NUMBER, 'latest'],
+      [MOCK_TO_FILTER, BASE_BLOCK_NUMBER, 'latest'],
+    ])
+
+    // Invalidate cache
+    await waitFor(() => {
+      expect(mockMutate).toBeCalledTimes(1)
+    })
+  })
+
+  it('should invalidate the cache if the from transfer filter return new event(s)', async () => {
+    mockQueryFilter.mockImplementation(
+      jest.fn((filter) => {
+        return filter === MOCK_FROM_FILTER
+          ? Promise.resolve([{ blockNumber: BASE_BLOCK_NUMBER + 1 }])
+          : Promise.resolve([])
+      }),
+    )
+
+    renderHook(() => useSafeTokenAllocationInvalidator())
+
+    expect(mockQueryFilter).not.toHaveBeenCalled()
+    expect(mockMutate).not.toHaveBeenCalled()
+
+    await waitFor(() => {
+      expect(setIntervalSpy).toHaveBeenCalledTimes(1)
+    })
+
+    // First interval
+    act(() => {
+      jest.runOnlyPendingTimers()
+    })
+
+    expect(mockQueryFilter).toHaveBeenCalledTimes(2)
+    expect(mockQueryFilter.mock.calls).toEqual([
+      [MOCK_FROM_FILTER, BASE_BLOCK_NUMBER, 'latest'],
+      [MOCK_TO_FILTER, BASE_BLOCK_NUMBER, 'latest'],
+    ])
+
+    // Invalidate cache
+    await waitFor(() => {
+      expect(mockMutate).toBeCalledTimes(1)
+    })
+  })
+
+  it('should invalidate the cache if both filters return new event(s)', async () => {
+    mockQueryFilter.mockResolvedValue([{ blockNumber: BASE_BLOCK_NUMBER + 1 }])
+
+    renderHook(() => useSafeTokenAllocationInvalidator())
+
+    expect(mockQueryFilter).not.toHaveBeenCalled()
+    expect(mockMutate).not.toHaveBeenCalled()
+
+    await waitFor(() => {
+      expect(setIntervalSpy).toHaveBeenCalledTimes(1)
+    })
+
+    // First interval
+    act(() => {
+      jest.runOnlyPendingTimers()
+    })
+
+    expect(mockQueryFilter).toHaveBeenCalledTimes(2)
+    expect(mockQueryFilter.mock.calls).toEqual([
+      [MOCK_FROM_FILTER, BASE_BLOCK_NUMBER, 'latest'],
+      [MOCK_TO_FILTER, BASE_BLOCK_NUMBER, 'latest'],
+    ])
+
+    // Invalidate cache
+    await waitFor(() => {
+      expect(mockMutate).toBeCalledTimes(1)
+    })
+  })
+
+  it('should not invalidate the cache if both filters return no event(s)', async () => {
+    mockQueryFilter.mockResolvedValue([])
+
+    renderHook(() => useSafeTokenAllocationInvalidator())
+
+    expect(mockQueryFilter).not.toHaveBeenCalled()
+    expect(mockMutate).not.toHaveBeenCalled()
+
+    await waitFor(() => {
+      expect(setIntervalSpy).toHaveBeenCalledTimes(1)
+    })
+
+    // First interval
+    act(() => {
+      jest.runOnlyPendingTimers()
+    })
+
+    expect(mockQueryFilter).toBeCalledTimes(2)
+    expect(mockQueryFilter.mock.calls).toEqual([
+      [MOCK_FROM_FILTER, BASE_BLOCK_NUMBER, 'latest'],
+      [MOCK_TO_FILTER, BASE_BLOCK_NUMBER, 'latest'],
+    ])
+
+    // Ensure mutation could have happened
+    await Promise.resolve()
+
+    // Don't invalidate cache
+    expect(mockMutate).not.toHaveBeenCalled()
+  })
+
+  it('should not invalidate the cache if the subsequent filter poll returns no event(s)', async () => {
+    mockQueryFilter.mockResolvedValue([{ blockNumber: BASE_BLOCK_NUMBER + 1 }])
+
+    renderHook(() => useSafeTokenAllocationInvalidator())
+
+    expect(mockQueryFilter).not.toHaveBeenCalled()
+    expect(mockMutate).not.toHaveBeenCalled()
+
+    await waitFor(() => {
+      expect(setIntervalSpy).toHaveBeenCalledTimes(1)
+    })
+
+    // First interval
+    act(() => {
+      jest.runOnlyPendingTimers()
+    })
+
+    expect(mockQueryFilter).toBeCalledTimes(2)
+    expect(mockQueryFilter.mock.calls).toEqual([
+      [MOCK_FROM_FILTER, BASE_BLOCK_NUMBER, 'latest'],
+      [MOCK_TO_FILTER, BASE_BLOCK_NUMBER, 'latest'],
+    ])
+
+    // Invalidate cache
+    await waitFor(() => {
+      expect(mockMutate).toBeCalledTimes(1)
+    })
+
+    mockQueryFilter.mockResolvedValue([])
+
+    // Second interval
+    act(() => {
+      jest.runOnlyPendingTimers()
+    })
+
+    expect(mockQueryFilter).toBeCalledTimes(4)
+    expect(mockQueryFilter.mock.calls).toEqual([
+      // Previous calls
+      [MOCK_FROM_FILTER, BASE_BLOCK_NUMBER, 'latest'],
+      [MOCK_TO_FILTER, BASE_BLOCK_NUMBER, 'latest'],
+      // New calls
+      [MOCK_FROM_FILTER, BASE_BLOCK_NUMBER + 1, 'latest'],
+      [MOCK_TO_FILTER, BASE_BLOCK_NUMBER + 1, 'latest'],
+    ])
+
+    // Ensure second mutation could have happened
+    await Promise.resolve()
+
+    // Don't invalidate cache
+    expect(mockMutate).toBeCalledTimes(1)
+  })
+})

--- a/src/hooks/useContractDelegate.ts
+++ b/src/hooks/useContractDelegate.ts
@@ -1,14 +1,12 @@
-import { useEffect } from 'react'
 import useSWR from 'swr'
-import { formatBytes32String, hexZeroPad } from 'ethers/lib/utils'
+import { formatBytes32String } from 'ethers/lib/utils'
 import type { JsonRpcProvider } from '@ethersproject/providers'
 
-import { CHAIN_DELEGATE_ID, DELEGATE_REGISTRY_ADDRESS, ZERO_ADDRESS } from '@/config/constants'
+import { CHAIN_DELEGATE_ID, ZERO_ADDRESS } from '@/config/constants'
 import { useWeb3 } from '@/hooks/useWeb3'
-import { getDelegateRegistryContract, getDelegateRegistryInterface } from '@/services/contracts/DelegateRegistry'
+import { getDelegateRegistryContract } from '@/services/contracts/DelegateRegistry'
 import { useWallet } from '@/hooks/useWallet'
 import type { FileDelegate } from '@/hooks/useDelegatesFile'
-import type { EventFilter } from '@ethersproject/abstract-provider'
 
 export type ContractDelegate = Pick<FileDelegate, 'address' | 'ens'>
 
@@ -52,47 +50,4 @@ export const useContractDelegate = () => {
   const wallet = useWallet()
 
   return useSWR(web3 ? [QUERY_KEY, wallet?.address, wallet?.chainId] : null, () => _getContractDelegate(web3))
-}
-
-const delegateRegistryInterface = getDelegateRegistryInterface()
-const setDelegateEvent = delegateRegistryInterface.getEventTopic(
-  delegateRegistryInterface.events['SetDelegate(address,bytes32,address)'],
-)
-
-export const useContractDelegateInvalidator = () => {
-  const web3 = useWeb3()
-  const { mutate } = useContractDelegate()
-
-  useEffect(() => {
-    if (!web3) {
-      return
-    }
-
-    let filter: EventFilter
-    ;(async () => {
-      const signer = web3.getSigner()
-
-      const address = await signer.getAddress()
-      const signerChainId = await signer.getChainId()
-
-      const delegateId = CHAIN_DELEGATE_ID[signerChainId]
-
-      if (!delegateId) {
-        return
-      }
-
-      filter = {
-        address: DELEGATE_REGISTRY_ADDRESS,
-        // Each topic has to be 32 bytes
-        topics: [setDelegateEvent, hexZeroPad(address, 32), formatBytes32String(delegateId)],
-      }
-
-      // Invalidate cache
-      web3.on(filter, mutate)
-    })()
-
-    return () => {
-      web3.off(filter)
-    }
-  }, [web3, mutate])
 }

--- a/src/hooks/useContractDelegateInvalidator.ts
+++ b/src/hooks/useContractDelegateInvalidator.ts
@@ -1,0 +1,57 @@
+import { useEffect } from 'react'
+import { formatBytes32String } from 'ethers/lib/utils'
+
+import { CHAIN_DELEGATE_ID, POLLING_INTERVAL } from '@/config/constants'
+import { useWeb3 } from '@/hooks/useWeb3'
+import { getDelegateRegistryContract } from '@/services/contracts/DelegateRegistry'
+import { useContractDelegate } from '@/hooks/useContractDelegate'
+
+export const useContractDelegateInvalidator = () => {
+  const web3 = useWeb3()
+  const { mutate } = useContractDelegate()
+
+  useEffect(() => {
+    if (!web3) {
+      return
+    }
+
+    let timeoutId: NodeJS.Timeout
+    ;(async () => {
+      const signer = web3.getSigner()
+
+      const signerChainId = await signer.getChainId()
+
+      const delegateId = CHAIN_DELEGATE_ID[signerChainId]
+
+      if (!delegateId) {
+        return
+      }
+
+      const signerAddress = await signer.getAddress()
+
+      const delegateRegistryContract = getDelegateRegistryContract(signer)
+
+      // setDelegate event
+      const filter = delegateRegistryContract.filters.SetDelegate(signerAddress, formatBytes32String(delegateId), null)
+
+      let prevBlockNumber = await web3.getBlockNumber()
+
+      timeoutId = setInterval(async () => {
+        const blocks = await delegateRegistryContract.queryFilter(filter, prevBlockNumber, 'latest')
+
+        if (blocks.length === 0) {
+          return
+        }
+
+        // Invalidate cache
+        mutate()
+
+        prevBlockNumber = blocks[blocks.length - 1].blockNumber
+      }, POLLING_INTERVAL)
+    })()
+
+    return () => {
+      clearInterval(timeoutId)
+    }
+  }, [web3, mutate])
+}

--- a/src/hooks/useSafeTokenAllocationInvalidator.ts
+++ b/src/hooks/useSafeTokenAllocationInvalidator.ts
@@ -1,0 +1,66 @@
+import { useEffect } from 'react'
+
+import { getSafeTokenContract } from '@/services/contracts/SafeToken'
+import { CHAIN_SAFE_TOKEN_ADDRESS, POLLING_INTERVAL } from '@/config/constants'
+import { useWeb3 } from '@/hooks/useWeb3'
+import { useSafeTokenAllocation } from '@/hooks/useSafeTokenAllocation'
+
+export const useSafeTokenAllocationInvalidator = () => {
+  const web3 = useWeb3()
+  const { mutate } = useSafeTokenAllocation()
+
+  useEffect(() => {
+    if (!web3) {
+      return
+    }
+
+    let timeoutId: NodeJS.Timeout
+    ;(async () => {
+      const signer = web3.getSigner()
+
+      const signerChainId = await signer.getChainId()
+
+      const safeTokenAddress = CHAIN_SAFE_TOKEN_ADDRESS[signerChainId]
+
+      if (!safeTokenAddress) {
+        return
+      }
+
+      const signerAddress = await signer.getAddress()
+
+      const safeTokenContract = getSafeTokenContract(safeTokenAddress, signer)
+
+      // Transfer event _from_ signer
+      const transferFromFilter = safeTokenContract.filters.Transfer(signerAddress, null, null)
+
+      // Transfer event _to_ signer
+      const transferToFilter = safeTokenContract.filters.Transfer(null, signerAddress, null)
+
+      let prevBlockNumber = await web3.getBlockNumber()
+
+      timeoutId = setInterval(async () => {
+        const [transferFromBlocks, transferToBlocks] = await Promise.all([
+          safeTokenContract.queryFilter(transferFromFilter, prevBlockNumber, 'latest'),
+          safeTokenContract.queryFilter(transferToFilter, prevBlockNumber, 'latest'),
+        ])
+
+        if (transferFromBlocks.length === 0 && transferToBlocks.length === 0) {
+          return
+        }
+
+        // Invalidate cache
+        mutate()
+
+        const prevTransferFromBlockNumber =
+          transferFromBlocks[transferFromBlocks.length - 1]?.blockNumber ?? prevBlockNumber
+        const prevTransferToBlockNumber = transferToBlocks[transferToBlocks.length - 1]?.blockNumber ?? prevBlockNumber
+
+        prevBlockNumber = Math.max(prevBlockNumber, prevTransferFromBlockNumber, prevTransferToBlockNumber)
+      }, POLLING_INTERVAL)
+    })()
+
+    return () => {
+      clearInterval(timeoutId)
+    }
+  }, [web3, mutate])
+}

--- a/src/services/contracts/DelegateRegistry.ts
+++ b/src/services/contracts/DelegateRegistry.ts
@@ -2,11 +2,7 @@ import type { JsonRpcSigner } from '@ethersproject/providers'
 
 import { DELEGATE_REGISTRY_ADDRESS } from '@/config/constants'
 import { DelegateRegistry__factory } from '@/types/contracts/delegate-registry'
-import type { DelegateRegistry, DelegateRegistryInterface } from '@/types/contracts/delegate-registry/DelegateRegistry'
-
-export const getDelegateRegistryInterface = (): DelegateRegistryInterface => {
-  return DelegateRegistry__factory.createInterface()
-}
+import type { DelegateRegistry } from '@/types/contracts/delegate-registry/DelegateRegistry'
 
 export const getDelegateRegistryContract = (signer: JsonRpcSigner): DelegateRegistry => {
   return DelegateRegistry__factory.connect(DELEGATE_REGISTRY_ADDRESS, signer)

--- a/src/services/contracts/SafeToken.ts
+++ b/src/services/contracts/SafeToken.ts
@@ -1,6 +1,12 @@
+import type { JsonRpcSigner } from '@ethersproject/providers'
+
 import { SafeToken__factory } from '@/types/contracts/safe-token'
-import type { SafeTokenInterface } from '@/types/contracts/safe-token/SafeToken'
+import type { SafeTokenInterface, SafeToken } from '@/types/contracts/safe-token/SafeToken'
 
 export const getSafeTokenInterface = (): SafeTokenInterface => {
   return SafeToken__factory.createInterface()
+}
+
+export const getSafeTokenContract = (safeTokenAddress: string, signer: JsonRpcSigner): SafeToken => {
+  return SafeToken__factory.connect(safeTokenAddress, signer)
 }


### PR DESCRIPTION
## What it solves

Excessive RPC calls

## How this PR fixes it

We no longer rely on `ethers`' `on` function as [it does not facilitate custom polling periods](https://docs.ethers.org/v5/concepts/events/). We instead `queryFilter` inside a 30 second interval, invalidating the cache if filter-relevant blocks are returned.

## How to test

Open the app as either a Safe App or DApp and observe no excessive log/block requests when compared to production, instead occuring every 30 seconds. They should trigger UI changes when the balance or delegate changes.