### PR TITLE
refactor: use string for `chainId` everywhere

### DIFF
--- a/src/components/ChainSwitcher/index.tsx
+++ b/src/components/ChainSwitcher/index.tsx
@@ -15,12 +15,12 @@ export const ChainSwitcher = (): ReactElement | null => {
   const defaultChain = useChain()
   const chainId = useChainId()
 
-  if (!wallet || wallet.chainId === chainId.toString()) {
+  if (!wallet || wallet.chainId === chainId) {
     return null
   }
 
   const handleChainSwitch = () => {
-    onboard?.setChain({ chainId: hexValue(chainId) })
+    onboard?.setChain({ chainId: hexValue(parseInt(chainId)) })
   }
 
   return (

--- a/src/components/ConnectWallet/index.tsx
+++ b/src/components/ConnectWallet/index.tsx
@@ -24,9 +24,9 @@ export const ConnectWallet = (): ReactElement => {
 
       // Here we check non-hardware wallets. Hardware wallets will always be on the correct
       // chain as onboard is only ever initialised with the current chain config
-      const isWrongChain = wallet && wallet.chainId !== chainId.toString()
+      const isWrongChain = wallet && wallet.chainId !== chainId
       if (isWrongChain) {
-        await onboard.setChain({ wallet: wallet.label, chainId: hexValue(chainId) })
+        await onboard.setChain({ wallet: wallet.label, chainId: hexValue(parseInt(chainId)) })
       }
     } catch {
       return

--- a/src/components/DashboardWidgets/ClaimingWidget.tsx
+++ b/src/components/DashboardWidgets/ClaimingWidget.tsx
@@ -86,7 +86,7 @@ const VotingPowerWidget = (): ReactElement => {
 
   const hasUnredeemedAllocation = vestingData?.some(({ isExpired, isRedeemed }) => !isExpired && !isRedeemed)
 
-  const claimingSafeAppUrl = getGovernanceAppSafeAppUrl(safe.chainId, safe.safeAddress)
+  const claimingSafeAppUrl = getGovernanceAppSafeAppUrl(safe.chainId.toString(), safe.safeAddress)
 
   return (
     <>

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -23,8 +23,8 @@ export const SAFE_URL = IS_PRODUCTION ? 'https://app.safe.global' : 'https://saf
 
 // Chains
 export const Chains = {
-  MAINNET: 1,
-  GOERLI: 5,
+  MAINNET: '1',
+  GOERLI: '5',
 }
 
 // Strictly type configuration for each chain above
@@ -39,8 +39,8 @@ export const CHAIN_SHORT_NAME: ChainConfig<string> = {
 
 // Token
 export const CHAIN_SAFE_TOKEN_ADDRESS: ChainConfig<string> = {
-  1: '0x5afe3855358e112b5647b952709e6165e1c1eeee',
-  5: '0x61fD3b6d656F39395e32f46E2050953376c3f5Ff',
+  [Chains.MAINNET]: '0x5afe3855358e112b5647b952709e6165e1c1eeee',
+  [Chains.GOERLI]: '0x61fD3b6d656F39395e32f46E2050953376c3f5Ff',
 }
 
 // Claiming

--- a/src/hooks/__tests__/useContractDelegate.test.ts
+++ b/src/hooks/__tests__/useContractDelegate.test.ts
@@ -30,19 +30,19 @@ describe('_getContractDelegate()', () => {
   })
 
   it('returns null if no address is defined', async () => {
-    const result = await _getContractDelegate(5, undefined, web3Provider)
+    const result = await _getContractDelegate('5', undefined, web3Provider)
 
     expect(result).toBe(null)
   })
 
   it('returns null if no provider is defined', async () => {
-    const result = await _getContractDelegate(5, SAFE_ADDRESS, undefined)
+    const result = await _getContractDelegate('5', SAFE_ADDRESS, undefined)
 
     expect(result).toBe(null)
   })
 
   it('ignore the ZERO_ADDRESS as delegate', async () => {
-    const delegateIDInBytes = formatBytes32String(CHAIN_DELEGATE_ID[5])
+    const delegateIDInBytes = formatBytes32String(CHAIN_DELEGATE_ID['5'])
 
     mockCall.mockImplementation((transaction) => {
       expect(transaction.to?.toString().toLowerCase()).toEqual(DELEGATE_REGISTRY_ADDRESS.toLowerCase())
@@ -54,14 +54,14 @@ describe('_getContractDelegate()', () => {
       return Promise.resolve(hexZeroPad(ZERO_ADDRESS, 32))
     })
 
-    const result = await _getContractDelegate(5, SAFE_ADDRESS, web3Provider)
+    const result = await _getContractDelegate('5', SAFE_ADDRESS, web3Provider)
 
     expect(mockCall).toBeCalledTimes(1)
     expect(result).toBe(null)
   })
 
   it('should encode the correct data and fetch the delegate on-chain once', async () => {
-    const delegateIDInBytes = formatBytes32String(CHAIN_DELEGATE_ID[5])
+    const delegateIDInBytes = formatBytes32String(CHAIN_DELEGATE_ID['5'])
 
     const delegateAddress = hexZeroPad('0x1', 20)
 
@@ -75,7 +75,7 @@ describe('_getContractDelegate()', () => {
       return Promise.resolve(hexZeroPad(delegateAddress, 32))
     })
 
-    const result = await _getContractDelegate(5, SAFE_ADDRESS, web3Provider)
+    const result = await _getContractDelegate('5', SAFE_ADDRESS, web3Provider)
 
     expect(mockCall).toBeCalledTimes(1)
     expect(result).toEqual({ address: delegateAddress, ens: 'test.eth' })

--- a/src/hooks/__tests__/useIsTokenPaused.test.ts
+++ b/src/hooks/__tests__/useIsTokenPaused.test.ts
@@ -18,7 +18,7 @@ describe('_getIsTokenPaused', () => {
   it('should return true on error', async () => {
     mockCall.mockImplementation(() => Promise.reject())
 
-    const result = await _getIsTokenPaused(5, web3Provider)
+    const result = await _getIsTokenPaused('5', web3Provider)
 
     expect(result).toBeTruthy()
     expect(mockCall).toBeCalledTimes(1)
@@ -27,7 +27,7 @@ describe('_getIsTokenPaused', () => {
   it('should return true if token is paused', async () => {
     mockCall.mockImplementation(async () => Promise.resolve(safeTokenInterface.encodeFunctionResult('paused', [true])))
 
-    const result = await _getIsTokenPaused(5, web3Provider)
+    const result = await _getIsTokenPaused('5', web3Provider)
 
     expect(result).toBeTruthy()
     expect(mockCall).toBeCalledTimes(1)
@@ -36,20 +36,20 @@ describe('_getIsTokenPaused', () => {
   it('should return false if token is unpaused', async () => {
     mockCall.mockImplementation(async () => Promise.resolve(safeTokenInterface.encodeFunctionResult('paused', [false])))
 
-    const result = await _getIsTokenPaused(5, web3Provider)
+    const result = await _getIsTokenPaused('5', web3Provider)
 
     expect(result).toBeFalsy()
     expect(mockCall).toBeCalledTimes(1)
   })
 
   it('returns null if no provider is defined', async () => {
-    const result = await _getIsTokenPaused(5, undefined)
+    const result = await _getIsTokenPaused('5', undefined)
 
     expect(result).toBe(null)
   })
 
   it('returns null if no Safe Token address is found for the current chain', async () => {
-    const result = await _getIsTokenPaused(1337, web3Provider)
+    const result = await _getIsTokenPaused('0', web3Provider)
 
     expect(result).toBe(null)
   })

--- a/src/hooks/__tests__/useVestingData.test.ts
+++ b/src/hooks/__tests__/useVestingData.test.ts
@@ -42,7 +42,7 @@ describe('useVestingData', () => {
   it('return an empty array if no allocations exist', async () => {
     global.fetch = jest.fn().mockImplementation(setupFetchStub('', 404))
 
-    const result = await _getVestingData(5, SAFE_ADDRESS, web3Provider)
+    const result = await _getVestingData('5', SAFE_ADDRESS, web3Provider)
     expect(result).toStrictEqual([])
   })
 
@@ -85,7 +85,7 @@ describe('useVestingData', () => {
       return Promise.resolve('0x')
     })
 
-    const result = await _getVestingData(5, SAFE_ADDRESS, web3Provider)
+    const result = await _getVestingData('5', SAFE_ADDRESS, web3Provider)
     expect(result).toStrictEqual([
       {
         tag: 'user',
@@ -138,7 +138,7 @@ describe('useVestingData', () => {
       return Promise.resolve('0x')
     })
 
-    const result = await _getVestingData(5, SAFE_ADDRESS, web3Provider)
+    const result = await _getVestingData('5', SAFE_ADDRESS, web3Provider)
     expect(result).toStrictEqual([
       {
         tag: 'user',
@@ -197,7 +197,7 @@ describe('useVestingData', () => {
       return Promise.resolve('0x')
     })
 
-    const result = await _getVestingData(5, SAFE_ADDRESS, web3Provider)
+    const result = await _getVestingData('5', SAFE_ADDRESS, web3Provider)
     expect(result).toStrictEqual([])
   })
 })

--- a/src/hooks/__tests__/useVotingPower.test.ts
+++ b/src/hooks/__tests__/useVotingPower.test.ts
@@ -17,17 +17,17 @@ describe('getVotingPower', () => {
   web3Provider.call = mockCall
 
   it('should return null if address is undefined', async () => {
-    const result = await _getVotingPower({ chainId: 5, web3: web3Provider, vestingData: [] })
+    const result = await _getVotingPower({ chainId: '5', web3: web3Provider, vestingData: [] })
     expect(result).toBe(null)
   })
 
   it('should return null if provider is undefined', async () => {
-    const result = await _getVotingPower({ chainId: 5, address: SAFE_ADDRESS, vestingData: [] })
+    const result = await _getVotingPower({ chainId: '5', address: SAFE_ADDRESS, vestingData: [] })
     expect(result).toBe(null)
   })
 
   it('should return 0 if no contract exists on the given chain', async () => {
-    const result = await _getVotingPower({ chainId: 0, address: SAFE_ADDRESS, web3: web3Provider, vestingData: [] })
+    const result = await _getVotingPower({ chainId: '0', address: SAFE_ADDRESS, web3: web3Provider, vestingData: [] })
     expect(result?.toNumber()).toEqual(0)
   })
 
@@ -40,7 +40,7 @@ describe('getVotingPower', () => {
       return Promise.resolve('0x')
     })
 
-    const result = await _getVotingPower({ chainId: 5, address: SAFE_ADDRESS, web3: web3Provider, vestingData: [] })
+    const result = await _getVotingPower({ chainId: '5', address: SAFE_ADDRESS, web3: web3Provider, vestingData: [] })
     expect(result?.toNumber()).toEqual(0)
   })
 
@@ -53,7 +53,7 @@ describe('getVotingPower', () => {
       return Promise.resolve('0x')
     })
 
-    const result = await _getVotingPower({ chainId: 5, address: SAFE_ADDRESS, web3: web3Provider, vestingData: [] })
+    const result = await _getVotingPower({ chainId: '5', address: SAFE_ADDRESS, web3: web3Provider, vestingData: [] })
     expect(result?.eq(parseEther('100'))).toBeTruthy()
   })
 
@@ -87,7 +87,7 @@ describe('getVotingPower', () => {
     })
 
     const result = await _getVotingPower({
-      chainId: 5,
+      chainId: '5',
       address: SAFE_ADDRESS,
       web3: web3Provider,
       vestingData: mockVestings,
@@ -125,7 +125,7 @@ describe('getVotingPower', () => {
     })
 
     const result = await _getVotingPower({
-      chainId: 5,
+      chainId: '5',
       address: SAFE_ADDRESS,
       web3: web3Provider,
       vestingData: mockAllocation,
@@ -163,7 +163,7 @@ describe('getVotingPower', () => {
     })
 
     const result = await _getVotingPower({
-      chainId: 5,
+      chainId: '5',
       address: SAFE_ADDRESS,
       web3: web3Provider,
       vestingData: mockAllocation,

--- a/src/hooks/useChain.ts
+++ b/src/hooks/useChain.ts
@@ -9,5 +9,5 @@ export const useChain = () => {
 
   const { data: chains } = useSWRImmutable([QUERY_KEY], getChainsConfig)
 
-  return chains?.results?.find((chain) => chain.chainId === chainId.toString())
+  return chains?.results?.find((chain) => chain.chainId === chainId)
 }

--- a/src/hooks/useChainId.ts
+++ b/src/hooks/useChainId.ts
@@ -7,7 +7,7 @@ export const defaultChainIdStore = new ExternalStore(_DEFAULT_CHAIN_ID)
 
 const supportedChains = Object.values(Chains)
 
-export const useChainId = (): number => {
+export const useChainId = (): string => {
   const isSafeApp = useIsSafeApp()
   const { safe } = useSafeAppsSDK()
   const chainId = defaultChainIdStore.useStore()!
@@ -16,8 +16,12 @@ export const useChainId = (): number => {
     return _DEFAULT_CHAIN_ID
   }
 
-  if (isSafeApp && supportedChains.includes(safe.chainId)) {
-    return safe.chainId
+  if (isSafeApp) {
+    const safeChainId = safe.chainId.toString()
+
+    if (supportedChains.includes(safeChainId)) {
+      return safeChainId
+    }
   }
 
   return chainId

--- a/src/hooks/useContractDelegate.ts
+++ b/src/hooks/useContractDelegate.ts
@@ -14,7 +14,7 @@ import type { FileDelegate } from '@/hooks/useDelegatesFile'
 export type ContractDelegate = Pick<FileDelegate, 'address' | 'ens'>
 
 export const _getContractDelegate = async (
-  chainId: number,
+  chainId: string,
   address?: string,
   web3?: JsonRpcProvider,
 ): Promise<ContractDelegate | null> => {

--- a/src/hooks/useIsTokenPaused.ts
+++ b/src/hooks/useIsTokenPaused.ts
@@ -10,7 +10,7 @@ import { useChainId } from '@/hooks/useChainId'
  * Fetches if the token is currently paused from on-chain.
  * If the fetching fails and initially we assume that the token is paused as the claimingViaModule should always work.
  */
-export const _getIsTokenPaused = async (chainId: number, web3?: JsonRpcProvider): Promise<boolean | null> => {
+export const _getIsTokenPaused = async (chainId: string, web3?: JsonRpcProvider): Promise<boolean | null> => {
   if (!web3) {
     return null
   }

--- a/src/hooks/useIsWrongChain.ts
+++ b/src/hooks/useIsWrongChain.ts
@@ -11,5 +11,5 @@ export const useIsWrongChain = (): boolean => {
     return false
   }
 
-  return wallet.chainId !== chainId.toString()
+  return wallet.chainId !== chainId
 }

--- a/src/hooks/useVestingData.ts
+++ b/src/hooks/useVestingData.ts
@@ -30,7 +30,7 @@ export type Vesting = VestingData & {
   amountClaimed: string
 }
 
-const fetchAllocation = async (chainId: number, address: string): Promise<VestingData[]> => {
+const fetchAllocation = async (chainId: string, address: string): Promise<VestingData[]> => {
   try {
     const response = await fetch(`${VESTING_URL}/${chainId}/${address}.json`)
 
@@ -102,7 +102,7 @@ const getValidVestingAllocation = (allocationData: Vesting[]): Vesting[] => {
 }
 
 export const _getVestingData = async (
-  chainId: number,
+  chainId: string,
   address?: string,
   web3?: JsonRpcProvider,
 ): Promise<Vesting[] | null> => {

--- a/src/hooks/useVotingPower.ts
+++ b/src/hooks/useVotingPower.ts
@@ -13,7 +13,7 @@ import { useWeb3 } from '@/hooks/useWeb3'
 
 const tokenInterface = getSafeTokenInterface()
 
-const fetchTokenBalance = async (chainId: number, safeAddress: string, provider: JsonRpcProvider): Promise<string> => {
+const fetchTokenBalance = async (chainId: string, safeAddress: string, provider: JsonRpcProvider): Promise<string> => {
   const safeTokenAddress = CHAIN_SAFE_TOKEN_ADDRESS[chainId]
 
   if (!safeTokenAddress) {
@@ -46,7 +46,7 @@ export const _getVotingPower = async ({
   web3,
   vestingData,
 }: {
-  chainId: number
+  chainId: string
   address?: string
   web3?: JsonRpcProvider
   vestingData: Vesting[]

--- a/src/services/delegate-registry.ts
+++ b/src/services/delegate-registry.ts
@@ -6,7 +6,7 @@ import { CHAIN_DELEGATE_ID } from '@/config/constants'
 import { getDelegateRegistryContract } from '@/services/contracts/DelegateRegistry'
 
 export const setDelegate = async (
-  chainId: number,
+  chainId: string,
   web3: JsonRpcProvider,
   delegateAddress: string,
 ): Promise<ContractTransaction | undefined> => {

--- a/src/utils/safe-apps.ts
+++ b/src/utils/safe-apps.ts
@@ -1,6 +1,6 @@
 import { CHAIN_SHORT_NAME, SAFE_URL, DEPLOYMENT_URL } from '@/config/constants'
 
-export const getGovernanceAppSafeAppUrl = (chainId: number, address: string): string => {
+export const getGovernanceAppSafeAppUrl = (chainId: string, address: string): string => {
   const url = new URL(`${SAFE_URL}/apps/open`)
 
   const shortName = CHAIN_SHORT_NAME[chainId]


### PR DESCRIPTION
## What it solves

`chainId`s in the code are now always strings

## How this PR fixes it

The `chainId` returned by the Safe Apps SDK is normally a number. This is now casted to a string as it aligns better with other repos. Associated references have also been changed to a string.

## How to test

- The claiming app link in the dashboard widget should open the Safe App.
- Switching to the correct chain in the DApp (via the account centre) should work.
In general, delegation and claiming should function as normal.
- Loading of set delegate, vesting data and current balance should work.
- Delegating should work.