### PR TITLE
fix: align brand

### DIFF
--- a/src/components/Claim/steps/ClaimOverview/index.tsx
+++ b/src/components/Claim/steps/ClaimOverview/index.tsx
@@ -162,7 +162,7 @@ const ClaimOverview = (): ReactElement => {
         How much do you want to claim?
       </Typography>
       <Typography variant="subtitle1" mb={2}>
-        Select all Tokens or define a custom amount.
+        Select all Safe Tokens or define a custom amount.
       </Typography>
 
       <Grid item container gap={2} flexWrap="nowrap" xs={12} mb={3}>
@@ -202,7 +202,7 @@ const ClaimOverview = (): ReactElement => {
       {isInvestorClaimingDisabled && (
         <InfoAlert>
           <Typography variant="subtitle2" mb={3}>
-            Claiming will be available once the token is transferable
+            Claiming will be available once the Safe Token is transferable
           </Typography>
         </InfoAlert>
       )}

--- a/src/components/Claim/steps/ClaimOverview/index.tsx
+++ b/src/components/Claim/steps/ClaimOverview/index.tsx
@@ -162,7 +162,7 @@ const ClaimOverview = (): ReactElement => {
         How much do you want to claim?
       </Typography>
       <Typography variant="subtitle1" mb={2}>
-        Select all tokens or define a custom amount.
+        Select all Tokens or define a custom amount.
       </Typography>
 
       <Grid item container gap={2} flexWrap="nowrap" xs={12} mb={3}>

--- a/src/components/Claim/steps/SuccessfulClaim/index.tsx
+++ b/src/components/Claim/steps/SuccessfulClaim/index.tsx
@@ -26,7 +26,7 @@ const SuccessfulClaim = (): ReactElement => {
       <Typography mb={4} color={textColor} textAlign="center">
         You successfully started claiming {stepperState?.claimedAmount || '0'} Tokens!
         <br />
-        Once the transaction is signed and executed, the tokens will be available in your Safe.
+        Once the transaction is signed and executed, the Tokens will be available in your Safe Account.
       </Typography>
 
       <Button variant="contained" color={buttonColor} onClick={onNext}>

--- a/src/components/Claim/steps/SuccessfulClaim/index.tsx
+++ b/src/components/Claim/steps/SuccessfulClaim/index.tsx
@@ -24,9 +24,9 @@ const SuccessfulClaim = (): ReactElement => {
       </Typography>
 
       <Typography mb={4} color={textColor} textAlign="center">
-        You successfully started claiming {stepperState?.claimedAmount || '0'} Tokens!
+        You successfully started claiming {stepperState?.claimedAmount || '0'} Safe Tokens!
         <br />
-        Once the transaction is signed and executed, the Tokens will be available in your Safe Account.
+        Once the transaction is signed and executed, the Safe Tokens will be available in your Safe Account.
       </Typography>
 
       <Button variant="contained" color={buttonColor} onClick={onNext}>

--- a/src/components/CustomDelegate/index.tsx
+++ b/src/components/CustomDelegate/index.tsx
@@ -57,7 +57,8 @@ export const CustomDelegate = (): ReactElement => {
   return (
     <>
       <Typography>
-        The wallet address can belong to any person but you cannot delegate to your own{isSafeApp ? ' Safe' : ''}.
+        The wallet address can belong to any person but you cannot delegate to{' '}
+        {isSafeApp ? 'your own Safe Account' : 'yourself'}.
       </Typography>
 
       <TextField

--- a/src/components/DashboardWidgets/ClaimingWidget.tsx
+++ b/src/components/DashboardWidgets/ClaimingWidget.tsx
@@ -118,7 +118,7 @@ const VotingPowerWidget = (): ReactElement => {
         </>
       ) : (
         <>
-          {hasUnredeemedAllocation && <Subtitle>You have unredeemed Tokens.</Subtitle>}
+          {hasUnredeemedAllocation && <Subtitle>You have unredeemed Safe Tokens.</Subtitle>}
           <Link
             href={claimingSafeAppUrl}
             rel="noopener noreferrer"

--- a/src/components/DashboardWidgets/ClaimingWidget.tsx
+++ b/src/components/DashboardWidgets/ClaimingWidget.tsx
@@ -44,7 +44,9 @@ const WIDGET_HEIGHT = 300
 const CtaWidget = (): ReactElement => {
   return (
     <div>
-      <Title>Become part of Safe&apos;s future</Title>
+      <Title>
+        Become part of <i>Safe</i>&apos;s future
+      </Title>
       <br />
       <Subtitle>
         Help us unlock ownership for everyone by joining the discussions on the{' '}
@@ -116,7 +118,7 @@ const VotingPowerWidget = (): ReactElement => {
         </>
       ) : (
         <>
-          {hasUnredeemedAllocation && <Subtitle>You have unredeemed tokens.</Subtitle>}
+          {hasUnredeemedAllocation && <Subtitle>You have unredeemed Tokens.</Subtitle>}
           <Link
             href={claimingSafeAppUrl}
             rel="noopener noreferrer"

--- a/src/components/Delegation/steps/SelectDelegate/index.tsx
+++ b/src/components/Delegation/steps/SelectDelegate/index.tsx
@@ -62,8 +62,8 @@ const SelectDelegate = (): ReactElement => {
       <Grid item xs={12} container alignItems="flex-end" justifyContent="space-between" gap={2}>
         <Typography>
           A delegate is someone you select to make governance decisions on your behalf. You still retain full ownership
-          of your Tokens, but your delegate will wield the voting power associated with those Tokens, including your
-          unvested allocation.
+          of your Safe Tokens, but your delegate will wield the voting power associated with those Tokens, including
+          your unvested allocation.
         </Typography>
 
         <DelegateSwitch delegateType={delegateType} setDelegateType={setDelegateType} />

--- a/src/components/Delegation/steps/SelectDelegate/index.tsx
+++ b/src/components/Delegation/steps/SelectDelegate/index.tsx
@@ -62,7 +62,7 @@ const SelectDelegate = (): ReactElement => {
       <Grid item xs={12} container alignItems="flex-end" justifyContent="space-between" gap={2}>
         <Typography>
           A delegate is someone you select to make governance decisions on your behalf. You still retain full ownership
-          of your tokens, but your delegate will wield the voting power associated with those tokens, including your
+          of your Tokens, but your delegate will wield the voting power associated with those Tokens, including your
           unvested allocation.
         </Typography>
 

--- a/src/components/EducationSeries/steps/Disclaimer/index.tsx
+++ b/src/components/EducationSeries/steps/Disclaimer/index.tsx
@@ -4,9 +4,11 @@ import type { ReactElement } from 'react'
 import { StepHeader } from '@/components/StepHeader'
 import { NavButtons } from '@/components/NavButtons'
 import { useEducationSeriesStepper } from '@/components/EducationSeries'
+import { useIsSafeApp } from '@/hooks/useIsSafeApp'
 
 const Disclaimer = (): ReactElement => {
   const { onBack, onNext } = useEducationSeriesStepper()
+  const isSafeApp = useIsSafeApp()
 
   return (
     <Grid container px={6} pt={5} pb={4}>
@@ -15,8 +17,8 @@ const Disclaimer = (): ReactElement => {
       </Grid>
 
       <Typography mb={3}>
-        This App is for our community to encourage Safe ecosystem contributors and users to unlock Safe{`{DAO}`}{' '}
-        governance.
+        This {isSafeApp ? 'Safe{App}' : 'App'} is for our community to encourage <i>Safe</i> ecosystem contributors and
+        users to unlock Safe{`{DAO}`} governance.
         <br />
         <br />
         THIS APP IS PROVIDED “AS IS” AND “AS AVAILABLE,” AT YOUR OWN RISK, AND WITHOUT WARRANTIES OF ANY KIND. We will
@@ -27,7 +29,7 @@ const Disclaimer = (): ReactElement => {
         By accessing this app, you represent and warrant
         <br />- that you are of legal age and that you will comply with any laws applicable to you and not engage in any
         illegal activities;
-        <br />- that you are claiming Safe tokens to participate in the Safe{`{DAO}`} governance process and that they
+        <br />- that you are claiming Safe Tokens to participate in the Safe{`{DAO}`} governance process and that they
         do not represent consideration for past or future services;
         <br />- that you, the country you are a resident of and your wallet address is not on any sanctions lists
         maintained by the United Nations, Switzerland, the EU, UK or the US;

--- a/src/components/EducationSeries/steps/Distribution/index.tsx
+++ b/src/components/EducationSeries/steps/Distribution/index.tsx
@@ -22,8 +22,8 @@ const Distribution = (): ReactElement => {
       </Grid>
 
       <Typography mb={3}>
-        Safe Tokens are distributed to stakeholders of the ecosystem interested in shaping the future of Safe and
-        smart-contract accounts.
+        Safe Tokens are distributed to stakeholders of the ecosystem interested in shaping the future of <i>Safe</i> and
+        Safe Accounts.
       </Typography>
       <Grid item xs={12}>
         <ExternalLink href={DISTRIBUTION_PROPOSAL_URL}>Read full proposal</ExternalLink>

--- a/src/components/EducationSeries/steps/SafeDao/index.tsx
+++ b/src/components/EducationSeries/steps/SafeDao/index.tsx
@@ -33,9 +33,9 @@ const SafeDao = (): ReactElement => {
       </Grid>
 
       <Typography mb={3}>
-        Safe{`{DAO}`} aims to foster a vibrant ecosystem of applications and wallets leveraging Safe smart contract
-        accounts. This will be achieved through data-backed discussions, grants, ecosystem investments, as well as
-        providing developer tools and infrastructure.
+        Safe{`{DAO}`} aims to foster a vibrant ecosystem of applications and wallets leveraging Safe Accounts. This will
+        be achieved through data-backed discussions, grants, ecosystem investments, as well as providing developer tools
+        and infrastructure.
       </Typography>
 
       <Typography fontWeight={700} variant="h3" mb={3}>
@@ -58,14 +58,14 @@ const SafeDao = (): ReactElement => {
         </Point>
 
         <Point>
-          Chat with the community - join our Safe <ExternalLink href={DISCORD_URL}>Discord</ExternalLink>.
+          Chat with the community - join our <i>Safe</i> <ExternalLink href={DISCORD_URL}>Discord</ExternalLink>.
         </Point>
 
         <Paper className={css.info}>
           <Typography variant="h4" fontWeight={700}>
             Now&hellip;
             <br />
-            Help decide on the future of ownership with $SAFE.
+            Help decide on the future of ownership with SAFE.
           </Typography>
         </Paper>
       </Box>

--- a/src/components/EducationSeries/steps/SafeInfo/index.tsx
+++ b/src/components/EducationSeries/steps/SafeInfo/index.tsx
@@ -59,12 +59,12 @@ const SafeInfo = (): ReactElement => {
       </Grid>
 
       <Typography variant="h3" fontWeight={700} mb={2}>
-        Why do we have a token?
+        Why do we have a Token?
       </Typography>
 
       <Typography mb={5}>
         As critical web3 infrastructure, <i>Safe</i> needs to be a community-owned, censorship resistant project, with a
-        committed ecosystem stewarding its decisions. A governance token is needed to help coordinate this effort.
+        committed ecosystem stewarding its decisions. A governance Token is needed to help coordinate this effort.
       </Typography>
 
       <NavButtons onNext={onNext} />

--- a/src/components/EducationSeries/steps/SafeInfo/index.tsx
+++ b/src/components/EducationSeries/steps/SafeInfo/index.tsx
@@ -14,19 +14,25 @@ const SafeInfo = (): ReactElement => {
   return (
     <Grid container px={6} pt={5} pb={4}>
       <Grid item xs={12} mb={3}>
-        <StepHeader title="What is Safe?" />
+        <StepHeader
+          title={
+            <>
+              What is <i>Safe</i>?
+            </>
+          }
+        />
       </Grid>
 
       <Typography mb={3}>
-        Safe is critical infrastructure for Web3. It is a programmable wallet that enables secure management of digital
-        assets, data and identity.
+        <i>Safe</i> is critical infrastructure for Web3. It is a programmable wallet that enables secure management of
+        digital assets, data and identity.
       </Typography>
 
       <Grid container mb={6} spacing={5}>
         <Grid item xs={12} sm={6}>
           <InfoBox>
             <Typography color="text.secondary" mb={1}>
-              Total Safes created
+              Total Safe Accounts created
             </Typography>
             <Box display="inline-flex" gap={1} alignItems="center">
               <LockIcon />
@@ -57,7 +63,7 @@ const SafeInfo = (): ReactElement => {
       </Typography>
 
       <Typography mb={5}>
-        As critical web3 infrastructure, Safe needs to be a community-owned, censorship resistant project, with a
+        As critical web3 infrastructure, <i>Safe</i> needs to be a community-owned, censorship resistant project, with a
         committed ecosystem stewarding its decisions. A governance token is needed to help coordinate this effort.
       </Typography>
 

--- a/src/components/EducationSeries/steps/SafeToken/index.tsx
+++ b/src/components/EducationSeries/steps/SafeToken/index.tsx
@@ -8,7 +8,7 @@ import { useEducationSeriesStepper } from '@/components/EducationSeries'
 
 import css from './styles.module.css'
 
-const InfoAccordion = ({ summaryText, details }: { summaryText: string; details: string[] }) => {
+const InfoAccordion = ({ summaryText, details }: { summaryText: ReactElement | string; details: string[] }) => {
   return (
     <Accordion className={css.accordion} variant="outlined">
       <AccordionSummary expandIcon={<ExpandMoreIcon />} className={css.summary}>
@@ -17,8 +17,8 @@ const InfoAccordion = ({ summaryText, details }: { summaryText: string; details:
 
       <AccordionDetails className={css.details}>
         <List className={css.list}>
-          {details.map((detail) => (
-            <ListItem key={detail}>{detail}</ListItem>
+          {details.map((detail, i) => (
+            <ListItem key={i}>{detail}</ListItem>
           ))}
         </List>
       </AccordionDetails>
@@ -32,17 +32,18 @@ const SafeToken = (): ReactElement => {
   return (
     <Grid container px={6} pt={5} pb={4}>
       <Grid item xs={12} mb={3}>
-        <StepHeader title="What exactly is the Safe token and what does it govern?" />
+        <StepHeader title="What exactly is the Safe Token and what does it govern?" />
       </Grid>
 
       <Typography mb={3}>
-        $SAFE is an ERC-20 governance token that stewards infrastructure components of the Safe ecosystem, including:
+        SAFE is an ERC-20 governance token that stewards infrastructure components of the <i>Safe</i> ecosystem,
+        including:
       </Typography>
 
       <InfoAccordion
-        summaryText="Safe Protocol"
+        summaryText="Safe{Core} Protocol"
         details={[
-          'Safe Deployments (core smart contract deployments across multiple networks)',
+          'Safe{Core} Deployments (smart contract deployments across multiple networks)',
           'Curation of “trusted lists” (token lists, dApp lists, module lists)',
         ]}
       />
@@ -50,14 +51,14 @@ const SafeToken = (): ReactElement => {
       <InfoAccordion
         summaryText="Interfaces"
         details={[
-          'Decentralized hosting of a Safe frontend using the safe.eth domain',
+          'Decentralized hosting of a Safe{Wallet} frontend using the safe.eth domain',
           'Decentralized hosting of governance frontends',
         ]}
       />
 
       <InfoAccordion
         summaryText="On-chain assets"
-        details={['ENS names', 'Outstanding Safe token supply', 'Other Safe Treasury assets (NFTs, tokens, etc.)']}
+        details={['ENS names', 'Outstanding Safe Token supply', 'Other Safe{DAO} Treasury assets (NFTs, tokens, etc.)']}
       />
 
       <InfoAccordion

--- a/src/components/Intro/index.tsx
+++ b/src/components/Intro/index.tsx
@@ -94,7 +94,7 @@ export const Intro = (): ReactElement => {
 
       {isClaimable && (
         <Button variant="contained" size="stretched" onClick={onClaim} disabled={isWrongChain}>
-          Claim Tokens
+          Claim Safe Tokens
         </Button>
       )}
 

--- a/src/components/Intro/index.tsx
+++ b/src/components/Intro/index.tsx
@@ -69,7 +69,7 @@ export const Intro = (): ReactElement => {
   }
   return (
     <Grid container flexDirection="column" alignItems="center" px={1} py={6}>
-      <SafeToken alt="Safe token logo" width={84} height={84} />
+      <SafeToken alt="Safe Token logo" width={84} height={84} />
 
       <Box mt={4} display="flex" flexDirection="column" alignItems="center">
         <TotalVotingPower />
@@ -94,7 +94,7 @@ export const Intro = (): ReactElement => {
 
       {isClaimable && (
         <Button variant="contained" size="stretched" onClick={onClaim} disabled={isWrongChain}>
-          Claim tokens
+          Claim Tokens
         </Button>
       )}
 

--- a/src/components/SelectedDelegate/index.tsx
+++ b/src/components/SelectedDelegate/index.tsx
@@ -86,7 +86,7 @@ export const SelectedDelegate = ({
       </Card>
       {hint && (
         <InfoAlert mt={2}>
-          <Typography>You only delegate your voting power and not the ownership of your Tokens.</Typography>
+          <Typography>You only delegate your voting power and not the ownership of your Safe Tokens.</Typography>
         </InfoAlert>
       )}
     </>

--- a/src/components/SelectedDelegate/index.tsx
+++ b/src/components/SelectedDelegate/index.tsx
@@ -86,7 +86,7 @@ export const SelectedDelegate = ({
       </Card>
       {hint && (
         <InfoAlert mt={2}>
-          <Typography>You only delegate your voting power and not the ownership of your tokens.</Typography>
+          <Typography>You only delegate your voting power and not the ownership of your Tokens.</Typography>
         </InfoAlert>
       )}
     </>

--- a/src/hooks/__tests__/useEnsResolution.test.ts
+++ b/src/hooks/__tests__/useEnsResolution.test.ts
@@ -389,7 +389,7 @@ describe('useEnsResolution()', () => {
 
     expect(web3Provider.resolveName).toHaveBeenCalled()
     expect(result.current[0]).toBeUndefined()
-    expect(result.current[1]).toEqual('You cannot delegate to your own Safe')
+    expect(result.current[1]).toEqual('You cannot delegate to your own Safe Account')
     expect(result.current[2]).toBeFalsy()
   })
 
@@ -450,7 +450,7 @@ describe('useEnsResolution()', () => {
 
     expect(web3Provider.resolveName).not.toHaveBeenCalled()
     expect(result.current[0]).toEqual(resolvedAddress)
-    expect(result.current[1]).toEqual('You cannot delegate to your own Safe')
+    expect(result.current[1]).toEqual('You cannot delegate to your own Safe Account')
     expect(result.current[2]).toBeFalsy()
   })
 

--- a/src/hooks/useEnsResolution.ts
+++ b/src/hooks/useEnsResolution.ts
@@ -43,7 +43,7 @@ export const useEnsResolution = (str: string, debounce = true): [string | undefi
       const checksummedAddress = getAddress(address)
 
       const error = sameAddress(address, safe.safeAddress)
-        ? 'You cannot delegate to your own Safe'
+        ? 'You cannot delegate to your own Safe Account'
         : sameAddress(address, wallet?.address || '')
         ? 'You cannot delegate to your own wallet'
         : undefined
@@ -86,7 +86,7 @@ export const useEnsResolution = (str: string, debounce = true): [string | undefi
 
       // Attempted to delegate to own Safe
       if (sameAddress(resolvedAddress, safe.safeAddress)) {
-        isMounted && setError('You cannot delegate to your own Safe')
+        isMounted && setError('You cannot delegate to your own Safe Account')
         isMounted && setLoading(false)
         return
       }

--- a/src/hooks/useSafeTokenAllocation.ts
+++ b/src/hooks/useSafeTokenAllocation.ts
@@ -93,7 +93,7 @@ const fetchTokenBalance = async (chainId: string, safeAddress: string, provider:
       data: tokenInterface.encodeFunctionData('balanceOf', [safeAddress]),
     })
   } catch (err) {
-    throw Error(`Error fetching Safe token balance:  ${err}`)
+    throw Error(`Error fetching Safe Token balance:  ${err}`)
   }
 }
 


### PR DESCRIPTION
## What it solves

Brand alignment

## How this PR fixes it

All of the following instances have been updated according to our [brand map](https://docs.google.com/presentation/d/1c7IHqREWFvKtc5ngV1uZBi9eDp2ocHld0fWLBkTyQPs).

"Safe" (project) -> "Safe" (italicised)
"Safe" (contract) -> "Safe Account"
"Safe" (interface) -> "Safe{Wallet}"
Token(s) / token(s)-> "SAFE" or "Safe Token(s)"
"Safe App" -> "Safe{App}"

## How to test it

Observe the correct mapping in the changed files.