### PR TITLE
refactor: improve `StepperFactory`

### DIFF
--- a/src/components/Claim/index.tsx
+++ b/src/components/Claim/index.tsx
@@ -1,4 +1,5 @@
 import { lazy } from 'react'
+import type { ReactElement } from 'react'
 
 import { createStepper } from '@/services/StepperFactory'
 
@@ -7,11 +8,18 @@ const steps = [
   lazy(() => import('@/components/Claim/steps/SuccessfulClaim')),
 ]
 
-const ClaimContext = createStepper({
-  steps,
-  state: { claimedAmount: '' },
-})
+type ClaimStepperState = {
+  claimedAmount: string
+}
+
+const ClaimContext = createStepper<ClaimStepperState>()
 
 export const useClaimStepper = ClaimContext.useStepper
 
-export const Claim = ClaimContext.Stepper
+export const Claim = (): ReactElement => {
+  const initialState: ClaimStepperState = {
+    claimedAmount: '',
+  }
+
+  return <ClaimContext.Provider steps={steps} initialState={initialState} />
+}

--- a/src/components/CustomDelegate/index.tsx
+++ b/src/components/CustomDelegate/index.tsx
@@ -18,7 +18,7 @@ export const CustomDelegate = (): ReactElement => {
   const delegate = useDelegate()
   const { onNext, setStepperState, stepperState } = useDelegationStepper()
 
-  const [search, setSearch] = useState(stepperState?.customDelegate?.ens || '')
+  const [search, setSearch] = useState(stepperState?.customDelegate?.ens || stepperState?.customDelegate?.address || '')
 
   const [ensAddress, ensError, ensLoading] = useEnsResolution(search)
   const isValidEnsAddress = ensAddress && isAddress(ensAddress)

--- a/src/components/CustomDelegate/index.tsx
+++ b/src/components/CustomDelegate/index.tsx
@@ -1,6 +1,6 @@
 import { CircularProgress, InputAdornment, TextField, Typography } from '@mui/material'
 import SearchIcon from '@mui/icons-material/Search'
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useMemo } from 'react'
 import CheckCircleRoundedIcon from '@mui/icons-material/CheckCircleRounded'
 import { isAddress } from 'ethers/lib/utils'
 import type { ReactElement, ChangeEvent } from 'react'
@@ -24,20 +24,22 @@ export const CustomDelegate = (): ReactElement => {
   const isValidEnsAddress = ensAddress && isAddress(ensAddress)
 
   const customDelegate = useMemo<Delegate | undefined>(() => {
-    if (isValidEnsAddress) {
-      return {
-        ens: isAddress(search) ? null : search || null,
-        address: ensAddress,
-      }
+    if (!isValidEnsAddress) {
+      return
     }
-  }, [ensAddress, isValidEnsAddress, search])
 
-  useEffect(() => {
+    const newCustomDelegate = {
+      ens: isAddress(search) ? null : search || null,
+      address: ensAddress,
+    }
+
     setStepperState((prev) => ({
       ...prev,
-      customDelegate,
+      customDelegate: newCustomDelegate,
     }))
-  }, [setStepperState, customDelegate])
+
+    return newCustomDelegate
+  }, [ensAddress, isValidEnsAddress, search, setStepperState])
 
   const onSearch = (event: ChangeEvent<HTMLInputElement>) => {
     setSearch(event.currentTarget.value)

--- a/src/components/Delegation/index.tsx
+++ b/src/components/Delegation/index.tsx
@@ -1,6 +1,9 @@
 import { lazy } from 'react'
+import type { ReactElement } from 'react'
 
 import { createStepper } from '@/services/StepperFactory'
+import { useDelegatesFile } from '@/hooks/useDelegatesFile'
+import { useDelegate } from '@/hooks/useDelegate'
 import type { FileDelegate } from '@/hooks/useDelegatesFile'
 import type { Delegate } from '@/hooks/useDelegate'
 import type { ContractDelegate } from '@/hooks/useContractDelegate'
@@ -17,15 +20,21 @@ type DelegationStepperState = {
   selectedDelegate?: Delegate
 }
 
-const DelegationContext = createStepper<DelegationStepperState>({
-  steps,
-  state: {
-    safeGuardian: undefined,
-    customDelegate: undefined,
-    selectedDelegate: undefined,
-  },
-})
+const DelegationContext = createStepper<DelegationStepperState>()
 
 export const useDelegationStepper = DelegationContext.useStepper
 
-export const Delegation = DelegationContext.Stepper
+export const Delegation = (): ReactElement => {
+  const delegate = useDelegate() ?? undefined
+  const { data: delegateFiles } = useDelegatesFile()
+
+  const safeGuardian = delegateFiles?.find(({ address }) => address === delegate?.address)
+
+  const initialState: DelegationStepperState = {
+    selectedDelegate: delegate,
+    customDelegate: safeGuardian ? undefined : delegate,
+    safeGuardian,
+  }
+
+  return <DelegationContext.Provider steps={steps} initialState={initialState} />
+}

--- a/src/components/Delegation/steps/SelectDelegate/index.tsx
+++ b/src/components/Delegation/steps/SelectDelegate/index.tsx
@@ -1,5 +1,5 @@
 import { Grid, Typography } from '@mui/material'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import type { ReactElement } from 'react'
 
 import { DelegateList } from '@/components/DelegateList'
@@ -7,7 +7,6 @@ import { DelegateSwitch } from '@/components/DelegateSwitch'
 import { CustomDelegate } from '@/components/CustomDelegate'
 import { StepHeader } from '@/components/StepHeader'
 import { useDelegationStepper } from '@/components/Delegation'
-import { useDelegate } from '@/hooks/useDelegate'
 import { useDelegatesFile } from '@/hooks/useDelegatesFile'
 import type { FileDelegate } from '@/hooks/useDelegatesFile'
 
@@ -27,31 +26,12 @@ const getDelegateType = (delegateFiles?: FileDelegate[], address?: string) => {
 }
 
 const SelectDelegate = (): ReactElement => {
-  const { stepperState, setStepperState } = useDelegationStepper()
-  const delegate = useDelegate()
+  const { stepperState } = useDelegationStepper()
   const { data: delegateFiles } = useDelegatesFile()
 
   const [delegateType, setDelegateType] = useState<DelegateType | undefined>(
     getDelegateType(delegateFiles, stepperState?.selectedDelegate?.address),
   )
-
-  // Initialize stepper state with contract delegate if it exists
-  useEffect(() => {
-    if (!delegate || stepperState?.customDelegate || stepperState?.safeGuardian) {
-      return
-    }
-
-    const safeGuardian = delegateFiles?.find(({ address }) => address === delegate?.address)
-
-    setStepperState((prev) => ({
-      ...prev,
-      selectedDelegate: delegate,
-      customDelegate: safeGuardian ? undefined : delegate,
-      safeGuardian,
-    }))
-
-    setDelegateType(getDelegateType(delegateFiles, delegate?.address))
-  }, [delegate, delegateFiles, setStepperState, stepperState])
 
   return (
     <Grid container p={6} gap={3}>

--- a/src/components/EducationSeries/index.tsx
+++ b/src/components/EducationSeries/index.tsx
@@ -1,4 +1,5 @@
 import { lazy } from 'react'
+import type { ReactElement } from 'react'
 
 import { createStepper } from '@/services/StepperFactory'
 
@@ -10,8 +11,10 @@ const steps = [
   lazy(() => import('@/components/EducationSeries/steps/Disclaimer')),
 ]
 
-const EducationSeriesContext = createStepper({ steps })
+const EducationSeriesContext = createStepper()
 
 export const useEducationSeriesStepper = EducationSeriesContext.useStepper
 
-export const EducationSeries = EducationSeriesContext.Stepper
+export const EducationSeries = (): ReactElement => {
+  return <EducationSeriesContext.Provider steps={steps} />
+}

--- a/src/hooks/useAddress.ts
+++ b/src/hooks/useAddress.ts
@@ -1,16 +1,10 @@
 import { useSafeAppsSDK } from '@gnosis.pm/safe-apps-react-sdk'
 
-import { useIsSafeApp } from '@/hooks/useIsSafeApp'
 import { useWallet } from '@/hooks/useWallet'
 
 export const useAddress = (): string | undefined => {
-  const isSafeApp = useIsSafeApp()
   const { safe } = useSafeAppsSDK()
   const wallet = useWallet()
 
-  if (isSafeApp) {
-    return safe.safeAddress
-  }
-
-  return wallet?.address
+  return safe.safeAddress || wallet?.address
 }

--- a/src/hooks/useAddress.ts
+++ b/src/hooks/useAddress.ts
@@ -6,5 +6,6 @@ export const useAddress = (): string | undefined => {
   const { safe } = useSafeAppsSDK()
   const wallet = useWallet()
 
+  // If using as Safe App, return Safe address, otherwise return wallet address
   return safe.safeAddress || wallet?.address
 }


### PR DESCRIPTION
## What it solves

`StepperFactory` improvements

## How this PR fixes it

Initial state is now provided directly to the `Stepper.Provider` instead of being initialised on each step.

## How to test

Navigate through the education series, claiming and delegation steppers and observe no change in behaviour.