### PR TITLE
fix: update claiming app data URL

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -45,7 +45,7 @@ export const CHAIN_SAFE_TOKEN_ADDRESS: ChainConfig<string> = {
 
 // Claiming
 const CLAIMING_DATA_URL = IS_PRODUCTION
-  ? 'https://safe-claiming-app-data.gnosis-safe.io'
+  ? 'https://safe-claiming-app-data.safe.global'
   : 'https://safe-claiming-app-data.staging.5afe.dev'
 
 export const GUARDIANS_URL = `${CLAIMING_DATA_URL}/guardians/guardians.json`

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -19,7 +19,7 @@ export const DEPLOYMENT_URL = IS_PRODUCTION
 
 export const GATEWAY_URL = IS_PRODUCTION ? 'https://safe-client.safe.global' : 'https://safe-client.staging.5afe.dev'
 
-export const SAFE_URL = IS_PRODUCTION ? 'https://app.safe.global' : 'https://safe-web-core.staging.5afe.dev'
+export const SAFE_URL = IS_PRODUCTION ? 'https://app.safe.global' : 'https://safe-wallet-web.staging.5afe.dev'
 
 // Chains
 export const Chains = {


### PR DESCRIPTION
## What it solves

Updates claiming data URL

## How this PR fixes it

`safe-claiming-app-data.gnosis-safe.io` has been exchanged with `safe-claiming-app-data.safe.global` as per [request](https://5afe.slack.com/archives/C04MQSC3R7Y/p1687260130435589).

## How to test it

Open the app with an address that has an allocation and observe it still correctly displaying.