### PR TITLE
fix: remove "Where's my wallet?" info

### DIFF
--- a/src/components/ConnectWallet/index.tsx
+++ b/src/components/ConnectWallet/index.tsx
@@ -19,7 +19,19 @@ export const ConnectWallet = (): ReactElement => {
     }
 
     try {
-      const wallets = await onboard.connectWallet()
+      const promise = onboard.connectWallet()
+
+      // Remove "Where's my wallet?" element
+      setTimeout(() => {
+        const onboardModal = document.querySelector('onboard-v2')?.shadowRoot
+        const wheresMyWallet = onboardModal?.querySelector('.wallets-container .notice-container')
+
+        if (wheresMyWallet) {
+          wheresMyWallet.remove()
+        }
+      }, 100)
+
+      const wallets = await promise
       const wallet = getConnectedWallet(wallets)
 
       // Here we check non-hardware wallets. Hardware wallets will always be on the correct


### PR DESCRIPTION
## What it solves

Resolves unclear warning.

## How this PR fixes it

This removes the "Where's my wallet?" info box.

## How to test it

Open the wallet connection modal and observe no "Why don't I see my wallet?" information in the modal.