### PR TITLE
fix: don't check WC v1 session for v2 reconnection

### DIFF
--- a/src/utils/onboard.ts
+++ b/src/utils/onboard.ts
@@ -43,13 +43,12 @@ const CGW_NAMES: { [key in WALLET_KEYS]: string } = {
 // We need to modify the module name as onboard dedupes modules with the same label and the WC v1 and v2 modules have the same
 // @see https://github.com/blocknative/web3-onboard/blob/d399e0b76daf7b363d6a74b100b2c96ccb14536c/packages/core/src/store/actions.ts#L419
 // TODO: When removing this, also remove the associated CSS in `onboard.css`
+export const WALLET_CONNECT_V1_MODULE_NAME = 'WalletConnect v1'
 const walletConnectV1 = (): WalletInit => {
   return (helpers) => {
-    const MODULE_LABEL = 'WalletConnect v1'
-
     const walletConnectModule = walletConnect({ version: 1, bridge: WC_BRIDGE })(helpers) as WalletModule
 
-    walletConnectModule.label = MODULE_LABEL
+    walletConnectModule.label = WALLET_CONNECT_V1_MODULE_NAME
 
     return walletConnectModule
   }

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -2,11 +2,12 @@ import { ProviderLabel } from '@web3-onboard/injected-wallets'
 import { getSafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
 
 import { local } from '@/services/storage/local'
+import { WALLET_CONNECT_V1_MODULE_NAME } from '@/utils/onboard'
 import type { ConnectedWallet } from '@/hooks/useWallet'
 
 export const WalletNames = {
   METAMASK: ProviderLabel.MetaMask,
-  WALLET_CONNECT: 'WalletConnect',
+  WALLET_CONNECT: WALLET_CONNECT_V1_MODULE_NAME,
 }
 
 export const isWalletUnlocked = async (walletName: string): Promise<boolean> => {


### PR DESCRIPTION
## What it solves

Resolves WC v1 session caching interfering with v2.

## How this PR fixes it

The local session of WC v1 is no longer checked when trying to auto-connect to v2.

## How to test it

Create a session with WC v1 and refresh. Observe that WC v2 does not try to auto-connect.