### PR TITLE
fix: upgrade `@web3-onboard/core`

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@mui/material": "^5.11.5",
     "@safe-global/safe-gateway-typescript-sdk": "^3.5.6",
     "@web3-onboard/coinbase": "^2.2.4",
-    "@web3-onboard/core": "2.20.1",
+    "@web3-onboard/core": "2.20.3",
     "@web3-onboard/injected-wallets": "^2.10.0",
     "@web3-onboard/keystone": "^2.3.7",
     "@web3-onboard/ledger": "^2.4.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4375,10 +4375,10 @@
     ethers "5.5.4"
     joi "17.9.1"
 
-"@web3-onboard/core@2.20.1":
-  version "2.20.1"
-  resolved "https://registry.yarnpkg.com/@web3-onboard/core/-/core-2.20.1.tgz#ad3a15aa6c1083d6da83fd9d06d5fe250e750b5a"
-  integrity sha512-OlNQUYBsbvy389AQD5VggqCRGvmiE7/w0LeLt6yyUwAksGnRPSpLjiPaOOjMAJFq0d3TnSX5yXbAoG1SRJM7ww==
+"@web3-onboard/core@2.20.3":
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/core/-/core-2.20.3.tgz#e123979f9360057cd184d715fdedc9f0bbf45941"
+  integrity sha512-2fm8kJ4T4DXvPNU7rjWCAxFFEZXx2Xz7LiUCg+qXvhiHzJBBxGOBbL81HwZk9hR3eZzWwQt9tLmbFx0G2uREow==
   dependencies:
     "@web3-onboard/common" "^2.3.3"
     bignumber.js "^9.0.0"


### PR DESCRIPTION
## What it solves

Resolves `key.pairing` error in console ([as in `saw-wallet-web`](https://github.com/safe-global/safe-wallet-web/issues/2137))

## How this PR fixes it

`@web3-onboard/core` has been updated, which includes the latest versions of all WC packages and [the fix](https://github.com/WalletConnect/walletconnect-monorepo/pull/2684) for the reported issue.

## How to test it

Connect to the app with a Safe via WC and observe no errors in either console.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
