### PR TITLE
[EPIC] SEP #5 - Contract interaction

### DIFF
--- a/src/components/Claim/steps/ClaimOverview/index.tsx
+++ b/src/components/Claim/steps/ClaimOverview/index.tsx
@@ -19,7 +19,7 @@ import { useIsTokenPaused } from '@/hooks/useIsTokenPaused'
 import { useTaggedAllocations } from '@/hooks/useTaggedAllocations'
 import { useIsWrongChain } from '@/hooks/useIsWrongChain'
 import { Sep5InfoBox } from '@/components/Sep5InfoBox'
-import { useMockSep5 } from '@/hooks/useMockSep5'
+import { SEP5_EXPIRATION } from '@/config/constants'
 import type { ClaimFlow } from '@/components/Claim'
 
 import css from './styles.module.css'
@@ -55,22 +55,19 @@ const ClaimOverview = ({ onNext }: { onNext: (data: ClaimFlow) => void }): React
 
   const { data: isTokenPaused } = useIsTokenPaused()
 
-  // TODO: Use real SEP #5 data
-  const fakeSep5ClaimExpiration = '01.01.1970 10:00 CET'
-  const sep5 = useMockSep5()
-  const hasSep5Allocation = Number(sep5.allocation) > 0
-
   // Allocation, vesting and voting power
   const { data: allocation } = useSafeTokenAllocation()
 
-  const { ecosystemVesting, investorVesting } = getVestingTypes(allocation?.vestingData ?? [])
+  const { sep5Vesting, ecosystemVesting, investorVesting } = getVestingTypes(allocation?.vestingData ?? [])
 
-  const { user, ecosystem, investor, total } = useTaggedAllocations()
+  const { sep5, user, ecosystem, investor, total } = useTaggedAllocations()
   const totalClaimableAmountInEth = formatEther(total.claimable)
 
   const decimals = getDecimalLength(total.inVesting)
 
   // Flags
+  const hasSep5Allocation = !!sep5Vesting
+
   const isInvestorClaimingDisabled = !!investorVesting && isTokenPaused
 
   const isAmountGTZero = !!amount && !amountError && Number.parseFloat(amount) > 0
@@ -103,6 +100,7 @@ const ClaimOverview = ({ onNext }: { onNext: (data: ClaimFlow) => void }): React
       safeAddress: safe.safeAddress,
       isMax: isMaxAmountSelected,
       amount: amount || '0',
+      sep5Claimable: sep5.claimable,
       userClaimable: user.claimable,
       investorClaimable: investor.claimable,
       isTokenPaused: !!isTokenPaused,
@@ -164,8 +162,8 @@ const ClaimOverview = ({ onNext }: { onNext: (data: ClaimFlow) => void }): React
           <Grid item xs={12} mt={1}>
             <InfoAlert>
               <Typography variant="body2">
-                Execute at least one claim of any amount of your allocation before {fakeSep5ClaimExpiration} otherwise
-                it will be transferred back to the Safe{`{DAO}`} treasurary.
+                Execute at least one claim of any amount of your allocation before {SEP5_EXPIRATION} otherwise it will
+                be transferred back to the Safe{`{DAO}`} treasurary.
               </Typography>
             </InfoAlert>
           </Grid>

--- a/src/components/Intro/index.tsx
+++ b/src/components/Intro/index.tsx
@@ -20,7 +20,6 @@ import { useWallet } from '@/hooks/useWallet'
 import { isSafe } from '@/utils/wallet'
 import { InfoBox } from '@/components/InfoBox'
 import { useIsDelegationPending } from '@/hooks/usePendingDelegations'
-import { useMockSep5 } from '@/hooks/useMockSep5'
 import { Sep5InfoBox } from '@/components/Sep5InfoBox'
 
 import css from './styles.module.css'
@@ -36,13 +35,8 @@ export const Intro = (): ReactElement => {
   const { isLoading, data: allocation } = useSafeTokenAllocation()
   const { total } = useTaggedAllocations()
 
-  // TODO: Use real SEP #5 data
-  const sep5 = useMockSep5()
-  const hasSep5Allocation = Number(sep5.allocation) > 0
-  const isSep5Claimable = Number(sep5.claimable) > 0
-
-  const hasAllocation = Number(total.allocation) > 0 || hasSep5Allocation
-  const isClaimable = Number(total.claimable) > 0 || isSep5Claimable
+  const hasAllocation = Number(total.allocation) > 0
+  const isClaimable = Number(total.claimable) > 0
 
   const isDelegating = useIsDelegationPending()
   const canDelegate =
@@ -103,11 +97,9 @@ export const Intro = (): ReactElement => {
             </Grid>
           )}
 
-          {hasSep5Allocation && (
-            <Grid item xs={12}>
-              <Sep5InfoBox />
-            </Grid>
-          )}
+          <Grid item xs={12}>
+            <Sep5InfoBox />
+          </Grid>
 
           {isClaimable && (
             <Grid item xs={12} display="flex" justifyContent="center">

--- a/src/components/Sep5DeadlineChip/index.tsx
+++ b/src/components/Sep5DeadlineChip/index.tsx
@@ -4,15 +4,13 @@ import type { ReactElement } from 'react'
 
 import ClockIcon from '@/public/images/clock.svg'
 import { TypographyChip } from '../TypographyChip'
+import { SEP5_EXPIRATION_DATE } from '@/config/constants'
 
 export const Sep5DeadlineChip = (props: TypographyProps): ReactElement => {
-  // TODO: Use real SEP #5 data
-  const fakeSep5ClaimDate = '01.01.1970'
-
   return (
     <TypographyChip {...props}>
       <SvgIcon component={ClockIcon} inheritViewBox fontSize="inherit" sx={{ mr: '6px' }} />
-      Until {fakeSep5ClaimDate}
+      Until {SEP5_EXPIRATION_DATE}
     </TypographyChip>
   )
 }

--- a/src/components/Sep5InfoBox/index.tsx
+++ b/src/components/Sep5InfoBox/index.tsx
@@ -1,30 +1,34 @@
-import type { ReactElement } from 'react'
 import { Typography } from '@mui/material'
+import { formatEther } from 'ethers/lib/utils'
+import type { ReactElement } from 'react'
 
-import { useMockSep5 } from '@/hooks/useMockSep5'
 import { formatAmount } from '@/utils/formatters'
 import { ExternalLink } from '@/components/ExternalLink'
 import { InfoBox } from '@/components/InfoBox'
 import { Sep5DeadlineChip } from '@/components/Sep5DeadlineChip'
+import { useSafeTokenAllocation } from '@/hooks/useSafeTokenAllocation'
+import { getVestingTypes } from '@/utils/vesting'
+import { SEP5_PROPOSAL_URL } from '@/config/constants'
 
-const SEP5_URL =
-  'https://snapshot.org/#/safe.eth/proposal/0xb4765551b4814b592d02ce67de05527ac1d2b88a8c814c4346ecc0c947c9b941'
+export const Sep5InfoBox = (): ReactElement | null => {
+  const { data: allocation } = useSafeTokenAllocation()
+  const { sep5Vesting } = getVestingTypes(allocation?.vestingData || [])
 
-export const Sep5InfoBox = (): ReactElement => {
-  // TODO: Use real SEP #5 data
-  const sep5 = useMockSep5()
+  if (!sep5Vesting) {
+    return null
+  }
 
   return (
     <InfoBox display="flex" alignItems="center" justifyContent="space-between">
       <div>
         <Typography variant="body2" color="text.secondary">
           As a result of{' '}
-          <ExternalLink href={SEP5_URL} icon={false}>
+          <ExternalLink href={SEP5_PROPOSAL_URL} icon={false}>
             SEP #5
           </ExternalLink>
           , you qualify for
         </Typography>
-        <Typography fontWeight={700}>{formatAmount(sep5.allocation, 2)} SAFE</Typography>
+        <Typography fontWeight={700}>{formatAmount(formatEther(sep5Vesting.amount), 2)} SAFE</Typography>
       </div>
       <Sep5DeadlineChip px={2} />
     </InfoBox>

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -53,6 +53,9 @@ export const GUARDIANS_URL = `${CLAIMING_DATA_URL}/guardians/guardians.json`
 export const GUARDIANS_IMAGE_URL = `${CLAIMING_DATA_URL}/guardians/images`
 export const VESTING_URL = `${CLAIMING_DATA_URL}/allocations`
 
+export const SEP5_EXPIRATION_DATE = '27.07.2023'
+export const SEP5_EXPIRATION = `${SEP5_EXPIRATION_DATE} 10:00 CET`
+
 // Delegation
 export const CHAIN_DELEGATE_ID: ChainConfig<string> = {
   [Chains.MAINNET]: 'safe.eth',
@@ -69,5 +72,8 @@ export const CHAIN_SNAPSHOT_URL: ChainConfig<string> = {
   [Chains.MAINNET]: `https://snapshot.org/#/${CHAIN_DELEGATE_ID[Chains.MAINNET]}`,
   [Chains.GOERLI]: `https://snapshot.org/#/${CHAIN_DELEGATE_ID[Chains.GOERLI]}`,
 }
+
+export const SEP5_PROPOSAL_URL =
+  'https://snapshot.org/#/safe.eth/proposal/0xb4765551b4814b592d02ce67de05527ac1d2b88a8c814c4346ecc0c947c9b941'
 
 export const DISCORD_URL = 'https://chat.safe.global'

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -53,7 +53,7 @@ export const GUARDIANS_URL = `${CLAIMING_DATA_URL}/guardians/guardians.json`
 export const GUARDIANS_IMAGE_URL = `${CLAIMING_DATA_URL}/guardians/images`
 export const VESTING_URL = `${CLAIMING_DATA_URL}/allocations`
 
-export const SEP5_EXPIRATION_DATE = '27.07.2023'
+export const SEP5_EXPIRATION_DATE = '27.10.2023'
 export const SEP5_EXPIRATION = `${SEP5_EXPIRATION_DATE} 10:00 CET`
 
 // Delegation

--- a/src/hooks/useAllocations.ts
+++ b/src/hooks/useAllocations.ts
@@ -50,7 +50,7 @@ const fetchAllocation = async (chainId: string, address: string): Promise<Alloca
 
     // TODO: Remove mock allocation when vesting is deployed
     const isCurrentChain = MOCK_SEP5_ALLOCATION.chainId.toString() === chainId
-    const isCurrentAddress = MOCK_SEP5_ALLOCATION.account === address
+    const isCurrentAddress = sameAddress(MOCK_SEP5_ALLOCATION.account, address)
 
     if (isCurrentChain && isCurrentAddress) {
       allocations.push(MOCK_SEP5_ALLOCATION)

--- a/src/hooks/useAllocations.ts
+++ b/src/hooks/useAllocations.ts
@@ -49,8 +49,8 @@ const fetchAllocation = async (chainId: string, address: string): Promise<Alloca
     const allocations: Allocation[] = await response.json()
 
     // TODO: Remove mock allocation when vesting is deployed
-    const isCurrentChain = allocations.some((allocation) => allocation.chainId.toString() === chainId)
-    const isCurrentAddress = allocations.some((allocation) => sameAddress(allocation.account, address))
+    const isCurrentChain = MOCK_SEP5_ALLOCATION.chainId.toString() === chainId
+    const isCurrentAddress = MOCK_SEP5_ALLOCATION.account === address
 
     if (isCurrentChain && isCurrentAddress) {
       allocations.push(MOCK_SEP5_ALLOCATION)

--- a/src/hooks/useMockSep5.ts
+++ b/src/hooks/useMockSep5.ts
@@ -1,8 +1,0 @@
-export const useMockSep5 = () => {
-  const mockAllocation = '12345'
-
-  return {
-    allocation: mockAllocation,
-    claimable: mockAllocation,
-  }
-}

--- a/src/hooks/useTaggedAllocations.ts
+++ b/src/hooks/useTaggedAllocations.ts
@@ -14,6 +14,10 @@ const getTotal = (...amounts: string[]) => {
 }
 
 export const useTaggedAllocations = (): {
+  sep5: {
+    claimable: string
+    inVesting: string
+  }
   user: {
     claimable: string
     inVesting: string
@@ -35,25 +39,31 @@ export const useTaggedAllocations = (): {
   const { data: allocation } = useSafeTokenAllocation()
 
   // Get vesting types
-  const { userVesting, ecosystemVesting, investorVesting } = getVestingTypes(allocation?.vestingData || [])
+  const { userVesting, sep5Vesting, ecosystemVesting, investorVesting } = getVestingTypes(allocation?.vestingData || [])
 
   // Calculate claimable vs. vested amounts for each vesting type
+  const [sep5Claimable, sep5InVesting] = useAmounts(sep5Vesting)
   const [userClaimable, userInVesting] = useAmounts(userVesting)
   const [ecosystemClaimable, ecosystemInVesting] = useAmounts(ecosystemVesting)
   const [investorClaimable, investorInVesting] = useAmounts(investorVesting)
 
   // Calculate total of claimable vs. vested amounts
-  const totalAmountClaimable = getTotal(userClaimable, ecosystemClaimable, investorClaimable)
+  const totalAmountClaimable = getTotal(sep5Claimable, userClaimable, ecosystemClaimable, investorClaimable)
 
-  const totalAmountInVesting = getTotal(userInVesting, ecosystemInVesting, investorInVesting)
+  const totalAmountInVesting = getTotal(sep5InVesting, userInVesting, ecosystemInVesting, investorInVesting)
 
   const totalAllocation = getTotal(
+    sep5Vesting?.amount || '0',
     userVesting?.amount || '0',
     ecosystemVesting?.amount || '0',
     investorVesting?.amount || '0',
   )
 
   return {
+    sep5: {
+      claimable: sep5Claimable,
+      inVesting: sep5InVesting,
+    },
     user: {
       claimable: userClaimable,
       inVesting: userInVesting,

--- a/src/utils/__tests__/airdrop.test.ts
+++ b/src/utils/__tests__/airdrop.test.ts
@@ -7,95 +7,354 @@ export const MAX_UINT128 = BigNumber.from('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF')
 
 describe('splitAirdropAmounts', () => {
   it('should always claim max uint128 if max is selected', () => {
-    const [userAmount, investorAmount, ecosystemAmount] = splitAirdropAmounts(
-      true,
-      '2000.0',
-      parseEther('1000').toString(),
-      '0',
-    )
+    const [sep5Amount, userAmount, investorAmount, ecosystemAmount] = splitAirdropAmounts({
+      isMax: true,
+      amount: '1000',
+      sep5AirdropClaimable: parseEther('2000').toString(),
+      userAirdropClaimable: parseEther('1000').toString(),
+      investorClaimable: '0',
+    })
+
+    expect(sep5Amount).toEqual(MAX_UINT128.toString())
     expect(userAmount).toEqual(MAX_UINT128.toString())
     expect(investorAmount).toEqual(MAX_UINT128.toString())
     expect(ecosystemAmount).toEqual(MAX_UINT128.toString())
   })
 
-  it('should only claim from user airdrop if amount <= userClaim', () => {
+  it('should only claim from SEP5 if claim <= SEP5', () => {
     {
-      const [userAmount, , ecosystemAmount] = splitAirdropAmounts(false, '1.0', parseEther('1000').toString(), '0')
+      const [sep5Amount, userAmount, investorAmount, ecosystemAmount] = splitAirdropAmounts({
+        isMax: false,
+        amount: '1000',
+        sep5AirdropClaimable: parseEther('1000').toString(),
+        userAirdropClaimable: '0',
+        investorClaimable: '0',
+      })
+
+      expect(sep5Amount).toEqual(parseEther('1000').toString())
+      expect(userAmount).toEqual('0')
+      expect(investorAmount).toEqual('0')
+      expect(ecosystemAmount).toEqual('0')
+    }
+    {
+      const [sep5Amount, userAmount, investorAmount, ecosystemAmount] = splitAirdropAmounts({
+        isMax: false,
+        amount: '1001',
+        sep5AirdropClaimable: parseEther('1000').toString(),
+        userAirdropClaimable: parseEther('1').toString(),
+        investorClaimable: '0',
+      })
+
+      expect(sep5Amount).toEqual(parseEther('1000').toString())
       expect(userAmount).toEqual(parseEther('1').toString())
-      expect(ecosystemAmount).toEqual('0')
-    }
-    {
-      const [userAmount, investorAmount, ecosystemAmount] = splitAirdropAmounts(
-        false,
-        '1000.0',
-        parseEther('1000').toString(),
-        '0',
-      )
-      expect(userAmount).toEqual(parseEther('1000').toString())
       expect(investorAmount).toEqual('0')
       expect(ecosystemAmount).toEqual('0')
     }
   })
 
-  it('should claim from ecosystem airdrop if amount > userClaim', () => {
+  it('should only claim from user if SEP5 is 0 and claim <= user', () => {
     {
-      const [userAmount, investorAmount, ecosystemAmount] = splitAirdropAmounts(
-        false,
-        '1000.00001',
-        parseEther('1000').toString(),
-        '0',
-      )
+      const [sep5Amount, userAmount, investorAmount, ecosystemAmount] = splitAirdropAmounts({
+        isMax: false,
+        amount: '1000',
+        sep5AirdropClaimable: '0',
+        userAirdropClaimable: parseEther('1000').toString(),
+        investorClaimable: '0',
+      })
+
+      expect(sep5Amount).toEqual('0')
       expect(userAmount).toEqual(parseEther('1000').toString())
       expect(investorAmount).toEqual('0')
-      expect(ecosystemAmount).toEqual(parseEther('0.00001').toString())
+      expect(ecosystemAmount).toEqual('0')
     }
     {
-      const [userAmount, investorAmount, ecosystemAmount] = splitAirdropAmounts(
-        false,
-        '2000',
-        parseEther('1000').toString(),
-        '0',
-      )
+      const [sep5Amount, userAmount, investorAmount, ecosystemAmount] = splitAirdropAmounts({
+        isMax: false,
+        amount: '1001',
+        sep5AirdropClaimable: '0',
+        userAirdropClaimable: parseEther('1000').toString(),
+        investorClaimable: parseEther('1').toString(),
+      })
+
+      expect(sep5Amount).toEqual('0')
       expect(userAmount).toEqual(parseEther('1000').toString())
-      expect(investorAmount).toEqual('0')
-      expect(ecosystemAmount).toEqual(parseEther('1000').toString())
+      expect(investorAmount).toEqual(parseEther('1').toString())
+      expect(ecosystemAmount).toEqual('0')
     }
   })
 
-  it('should claim from investor airdrop if amount >= investor allocation', () => {
+  it('should only claim from investor if SEP5/user are 0 and claim <= investor', () => {
     {
-      const [userAmount, investorAmount, ecosystemAmount] = splitAirdropAmounts(
-        false,
-        '1000',
-        '0',
-        parseEther('1000').toString(),
-      )
+      const [sep5Amount, userAmount, investorAmount, ecosystemAmount] = splitAirdropAmounts({
+        isMax: false,
+        amount: '1000',
+        sep5AirdropClaimable: '0',
+        userAirdropClaimable: '0',
+        investorClaimable: parseEther('1000').toString(),
+      })
+
+      expect(sep5Amount).toEqual('0')
       expect(userAmount).toEqual('0')
       expect(investorAmount).toEqual(parseEther('1000').toString())
       expect(ecosystemAmount).toEqual('0')
     }
     {
-      const [userAmount, investorAmount, ecosystemAmount] = splitAirdropAmounts(
-        false,
-        '0.002',
-        '0',
-        parseEther('1000').toString(),
-      )
+      const [sep5Amount, userAmount, investorAmount, ecosystemAmount] = splitAirdropAmounts({
+        isMax: false,
+        amount: '1001',
+        sep5AirdropClaimable: '0',
+        userAirdropClaimable: '0',
+        investorClaimable: parseEther('1000').toString(),
+      })
+
+      expect(sep5Amount).toEqual('0')
       expect(userAmount).toEqual('0')
-      expect(investorAmount).toEqual(parseEther('0.002').toString())
+      expect(investorAmount).toEqual(parseEther('1000').toString())
+      expect(ecosystemAmount).toEqual(parseEther('1').toString())
+    }
+  })
+
+  it('should only claim from ecosystem if SEP5/user/investor are 0 and claim <= ecosystem', () => {
+    const [sep5Amount, userAmount, investorAmount, ecosystemAmount] = splitAirdropAmounts({
+      isMax: false,
+      amount: '1000',
+      sep5AirdropClaimable: '0',
+      userAirdropClaimable: '0',
+      investorClaimable: '0',
+    })
+
+    expect(sep5Amount).toEqual('0')
+    expect(userAmount).toEqual('0')
+    expect(investorAmount).toEqual('0')
+    expect(ecosystemAmount).toEqual(parseEther('1000').toString())
+  })
+
+  it('should only claim from SEP5/user if claim <= SEP5 + user', () => {
+    {
+      const [sep5Amount, userAmount, investorAmount, ecosystemAmount] = splitAirdropAmounts({
+        isMax: false,
+        amount: '1000',
+        sep5AirdropClaimable: parseEther('500').toString(),
+        userAirdropClaimable: parseEther('500').toString(),
+        investorClaimable: '0',
+      })
+
+      expect(sep5Amount).toEqual(parseEther('500').toString())
+      expect(userAmount).toEqual(parseEther('500').toString())
+      expect(investorAmount).toEqual('0')
+      expect(ecosystemAmount).toEqual('0')
+    }
+    {
+      const [sep5Amount, userAmount, investorAmount, ecosystemAmount] = splitAirdropAmounts({
+        isMax: false,
+        amount: '1001',
+        sep5AirdropClaimable: parseEther('500').toString(),
+        userAirdropClaimable: parseEther('500').toString(),
+        investorClaimable: parseEther('1').toString(),
+      })
+
+      expect(sep5Amount).toEqual(parseEther('500').toString())
+      expect(userAmount).toEqual(parseEther('500').toString())
+      expect(investorAmount).toEqual(parseEther('1').toString())
       expect(ecosystemAmount).toEqual('0')
     }
   })
 
-  it('should claim from user, investor and ecosystem airdrop if amount > user + investor', () => {
-    const [userAmount, investorAmount, ecosystemAmount] = splitAirdropAmounts(
-      false,
-      '2000',
-      parseEther('500').toString(),
-      parseEther('1000').toString(),
-    )
-    expect(userAmount).toEqual(parseEther('500').toString())
-    expect(investorAmount).toEqual(parseEther('1000').toString())
+  it('should only claim from SEP5/investor if user is 0 and claim <= SEP5 + investor', () => {
+    {
+      const [sep5Amount, userAmount, investorAmount, ecosystemAmount] = splitAirdropAmounts({
+        isMax: false,
+        amount: '1000',
+        sep5AirdropClaimable: parseEther('500').toString(),
+        userAirdropClaimable: '0',
+        investorClaimable: parseEther('500').toString(),
+      })
+
+      expect(sep5Amount).toEqual(parseEther('500').toString())
+      expect(userAmount).toEqual('0')
+      expect(investorAmount).toEqual(parseEther('500').toString())
+      expect(ecosystemAmount).toEqual('0')
+    }
+    {
+      const [sep5Amount, userAmount, investorAmount, ecosystemAmount] = splitAirdropAmounts({
+        isMax: false,
+        amount: '1001',
+        sep5AirdropClaimable: parseEther('500').toString(),
+        userAirdropClaimable: '0',
+        investorClaimable: parseEther('500').toString(),
+      })
+
+      expect(sep5Amount).toEqual(parseEther('500').toString())
+      expect(userAmount).toEqual('0')
+      expect(investorAmount).toEqual(parseEther('500').toString())
+      expect(ecosystemAmount).toEqual(parseEther('1').toString())
+    }
+  })
+
+  it('should only claim from SEP5/ecosystem is user/investor are 0 and claim > SEP5', () => {
+    const [sep5Amount, userAmount, investorAmount, ecosystemAmount] = splitAirdropAmounts({
+      isMax: false,
+      amount: '1000',
+      sep5AirdropClaimable: parseEther('500').toString(),
+      userAirdropClaimable: '0',
+      investorClaimable: '0',
+    })
+
+    expect(sep5Amount).toEqual(parseEther('500').toString())
+    expect(userAmount).toEqual('0')
+    expect(investorAmount).toEqual('0')
     expect(ecosystemAmount).toEqual(parseEther('500').toString())
+  })
+
+  it('should only claim from user/investor if SEP5 is 0 and claim <= user + investor', () => {
+    {
+      const [sep5Amount, userAmount, investorAmount, ecosystemAmount] = splitAirdropAmounts({
+        isMax: false,
+        amount: '1000',
+        sep5AirdropClaimable: '0',
+        userAirdropClaimable: parseEther('500').toString(),
+        investorClaimable: parseEther('500').toString(),
+      })
+
+      expect(sep5Amount).toEqual('0')
+      expect(userAmount).toEqual(parseEther('500').toString())
+      expect(investorAmount).toEqual(parseEther('500').toString())
+      expect(ecosystemAmount).toEqual('0')
+    }
+    {
+      const [sep5Amount, userAmount, investorAmount, ecosystemAmount] = splitAirdropAmounts({
+        isMax: false,
+        amount: '1001',
+        sep5AirdropClaimable: '0',
+        userAirdropClaimable: parseEther('500').toString(),
+        investorClaimable: parseEther('500').toString(),
+      })
+
+      expect(sep5Amount).toEqual('0')
+      expect(userAmount).toEqual(parseEther('500').toString())
+      expect(investorAmount).toEqual(parseEther('500').toString())
+      expect(ecosystemAmount).toEqual(parseEther('1').toString())
+    }
+  })
+
+  it('should only claim from user/ecosystem if SEP5/investor are 0 and claim > user', () => {
+    const [sep5Amount, userAmount, investorAmount, ecosystemAmount] = splitAirdropAmounts({
+      isMax: false,
+      amount: '1000',
+      sep5AirdropClaimable: '0',
+      userAirdropClaimable: parseEther('500').toString(),
+      investorClaimable: '0',
+    })
+
+    expect(sep5Amount).toEqual('0')
+    expect(userAmount).toEqual(parseEther('500').toString())
+    expect(investorAmount).toEqual('0')
+    expect(ecosystemAmount).toEqual(parseEther('500').toString())
+  })
+
+  it('should only claim from investor/ecosystem if SEP5/user are 0 and claim > investor', () => {
+    const [sep5Amount, userAmount, investorAmount, ecosystemAmount] = splitAirdropAmounts({
+      isMax: false,
+      amount: '1000',
+      sep5AirdropClaimable: '0',
+      userAirdropClaimable: '0',
+      investorClaimable: parseEther('500').toString(),
+    })
+
+    expect(sep5Amount).toEqual('0')
+    expect(userAmount).toEqual('0')
+    expect(investorAmount).toEqual(parseEther('500').toString())
+    expect(ecosystemAmount).toEqual(parseEther('500').toString())
+  })
+
+  it('should only claim from SEP5/user/investor if claim <= SEP5 + user + investor', () => {
+    {
+      const [sep5Amount, userAmount, investorAmount, ecosystemAmount] = splitAirdropAmounts({
+        isMax: false,
+        amount: '900',
+        sep5AirdropClaimable: parseEther('300').toString(),
+        userAirdropClaimable: parseEther('300').toString(),
+        investorClaimable: parseEther('300').toString(),
+      })
+
+      expect(sep5Amount).toEqual(parseEther('300').toString())
+      expect(userAmount).toEqual(parseEther('300').toString())
+      expect(investorAmount).toEqual(parseEther('300').toString())
+      expect(ecosystemAmount).toEqual('0')
+    }
+    {
+      const [sep5Amount, userAmount, investorAmount, ecosystemAmount] = splitAirdropAmounts({
+        isMax: false,
+        amount: '901',
+        sep5AirdropClaimable: parseEther('300').toString(),
+        userAirdropClaimable: parseEther('300').toString(),
+        investorClaimable: parseEther('300').toString(),
+      })
+
+      expect(sep5Amount).toEqual(parseEther('300').toString())
+      expect(userAmount).toEqual(parseEther('300').toString())
+      expect(investorAmount).toEqual(parseEther('300').toString())
+      expect(ecosystemAmount).toEqual(parseEther('1').toString())
+    }
+  })
+
+  it('should only claim from SEP5/user/ecosystem if investor is 0 and claim > SEP5 + user', () => {
+    const [sep5Amount, userAmount, investorAmount, ecosystemAmount] = splitAirdropAmounts({
+      isMax: false,
+      amount: '900',
+      sep5AirdropClaimable: parseEther('300').toString(),
+      userAirdropClaimable: parseEther('300').toString(),
+      investorClaimable: '0',
+    })
+
+    expect(sep5Amount).toEqual(parseEther('300').toString())
+    expect(userAmount).toEqual(parseEther('300').toString())
+    expect(investorAmount).toEqual('0')
+    expect(ecosystemAmount).toEqual(parseEther('300').toString())
+  })
+
+  it('should only claim from SEP5/investor/ecosystem if user is 0 and claim > SEP5 + investor', () => {
+    const [sep5Amount, userAmount, investorAmount, ecosystemAmount] = splitAirdropAmounts({
+      isMax: false,
+      amount: '900',
+      sep5AirdropClaimable: parseEther('300').toString(),
+      userAirdropClaimable: '0',
+      investorClaimable: parseEther('300').toString(),
+    })
+
+    expect(sep5Amount).toEqual(parseEther('300').toString())
+    expect(userAmount).toEqual('0')
+    expect(investorAmount).toEqual(parseEther('300').toString())
+    expect(ecosystemAmount).toEqual(parseEther('300').toString())
+  })
+
+  it('should only claim from user/investor/ecosystem if SEP5 is 0 and claim > user + investor', () => {
+    const [sep5Amount, userAmount, investorAmount, ecosystemAmount] = splitAirdropAmounts({
+      isMax: false,
+      amount: '900',
+      sep5AirdropClaimable: '0',
+      userAirdropClaimable: parseEther('300').toString(),
+      investorClaimable: parseEther('300').toString(),
+    })
+
+    expect(sep5Amount).toEqual('0')
+    expect(userAmount).toEqual(parseEther('300').toString())
+    expect(investorAmount).toEqual(parseEther('300').toString())
+    expect(ecosystemAmount).toEqual(parseEther('300').toString())
+  })
+
+  it('should only claim from SEP5/user/investor/ecosystem if claim > SEP5 + user + investor', () => {
+    const [sep5Amount, userAmount, investorAmount, ecosystemAmount] = splitAirdropAmounts({
+      isMax: false,
+      amount: '1200',
+      sep5AirdropClaimable: parseEther('300').toString(),
+      userAirdropClaimable: parseEther('300').toString(),
+      investorClaimable: parseEther('300').toString(),
+    })
+
+    expect(sep5Amount).toEqual(parseEther('300').toString())
+    expect(userAmount).toEqual(parseEther('300').toString())
+    expect(investorAmount).toEqual(parseEther('300').toString())
+    expect(ecosystemAmount).toEqual(parseEther('300').toString())
   })
 })

--- a/src/utils/__tests__/claim.test.ts
+++ b/src/utils/__tests__/claim.test.ts
@@ -8,6 +8,7 @@ const airdropInterface = getAirdropInterface()
 
 describe('createClaimTxs', () => {
   const mockUserAirdropAddress = hexZeroPad('0x2', 20)
+  const mockSep5AirdropAddress = hexZeroPad('0x7', 20)
   const mockInvestorVestingAddress = hexZeroPad('0x4', 20)
 
   it('redeem + claim user airdrop while paused', () => {
@@ -38,6 +39,7 @@ describe('createClaimTxs', () => {
       investorClaimable: '0',
       isMax: false,
       userClaimable: parseEther('100').toString(),
+      sep5Claimable: '0',
       isTokenPaused: true,
     })
 
@@ -63,6 +65,118 @@ describe('createClaimTxs', () => {
     // check to address
     expect(txs[0].to.toLowerCase()).toEqual(mockUserAirdropAddress)
     expect(txs[1].to.toLowerCase()).toEqual(mockUserAirdropAddress)
+  })
+
+  it('redeem + claim SEP5 airdrop while paused', () => {
+    const safeAddress = hexZeroPad('0x5afe', 20)
+
+    const vestingData: Vesting[] = [
+      {
+        isExpired: false,
+        account: safeAddress,
+        amount: parseEther('200').toString(),
+        amountClaimed: '0',
+        chainId: 5,
+        contract: mockSep5AirdropAddress,
+        curve: 0,
+        durationWeeks: 416,
+        isRedeemed: false,
+        proof: ['0x4697528f2cd5e98bce29be252b25ed33b79d8f0245bb7a3d0f00bb32e50128bb'],
+        startDate: 10000,
+        tag: 'user_v2',
+        vestingId: '0xabfe3d0bfb3df17a4aa39d6967f722ff82c765601417a4957434023c97d5b111',
+      },
+    ]
+
+    const txs = createClaimTxs({
+      vestingData,
+      amount: '200',
+      safeAddress,
+      investorClaimable: '0',
+      isMax: false,
+      userClaimable: '0',
+      sep5Claimable: parseEther('200').toString(),
+      isTokenPaused: true,
+    })
+
+    expect(txs).toHaveLength(2)
+
+    const decodedRedeemTx = airdropInterface.decodeFunctionData('redeem', txs[0].data)
+    const decodedClaimTx = airdropInterface.decodeFunctionData('claimVestedTokensViaModule', txs[1].data)
+    /*
+        uint8 curveType,
+        uint16 durationWeeks,
+        uint64 startDate,
+        uint128 amount,
+        bytes32[] calldata proof
+    */
+    expect(decodedRedeemTx[0]).toEqual(0)
+    expect(decodedRedeemTx[1]).toEqual(416)
+    expect(decodedRedeemTx[2].toString()).toEqual('10000')
+    expect(decodedRedeemTx[3].toString()).toEqual(parseEther('200').toString())
+
+    expect(decodedClaimTx[1].toString().toLowerCase()).toEqual(safeAddress) // beneficiary
+    expect(decodedClaimTx[2].toString()).toEqual(parseEther('200').toString()) // amount
+
+    // check to address
+    expect(txs[0].to.toLowerCase()).toEqual(mockSep5AirdropAddress)
+    expect(txs[1].to.toLowerCase()).toEqual(mockSep5AirdropAddress)
+  })
+
+  it('redeem + claim SEP5 airdrop first', () => {
+    const safeAddress = hexZeroPad('0x5afe', 20)
+
+    const vestingData: Vesting[] = [
+      {
+        isExpired: false,
+        account: safeAddress,
+        amount: parseEther('100').toString(),
+        amountClaimed: '0',
+        chainId: 5,
+        contract: mockUserAirdropAddress,
+        curve: 0,
+        durationWeeks: 416,
+        isRedeemed: true,
+        proof: ['0x4697528f2cd5e98bce29be252b25ed33b79d8f0245bb7a3d0f00bb32e50128bb'],
+        startDate: 10000,
+        tag: 'user',
+        vestingId: '0xabfe3d0bfb3df17a4aa39d6967f722ff82c765601417a4957434023c97d5b111',
+      },
+      {
+        isExpired: false,
+        account: safeAddress,
+        amount: parseEther('50').toString(),
+        amountClaimed: '0',
+        chainId: 5,
+        contract: mockSep5AirdropAddress,
+        curve: 0,
+        durationWeeks: 416,
+        isRedeemed: false,
+        proof: ['0x4697528f2cd5e98bce29be252b25ed33b79d8f0245bb7a3d0f00bb32e50128bb'],
+        startDate: 10000,
+        tag: 'user_v2',
+        vestingId: '0xabfe3d0bfb3df17a4aa39d6967f722ff82c765601417a4957434023c97d5b111',
+      },
+    ]
+
+    const txs = createClaimTxs({
+      vestingData,
+      amount: '150',
+      safeAddress,
+      investorClaimable: '0',
+      isMax: false,
+      userClaimable: parseEther('50').toString(),
+      sep5Claimable: parseEther('100').toString(),
+      isTokenPaused: true,
+    })
+
+    expect(txs).toHaveLength(3)
+
+    // check to address
+    expect(txs[0].to.toLowerCase()).toEqual(mockSep5AirdropAddress)
+    expect(txs[1].to.toLowerCase()).toEqual(mockSep5AirdropAddress)
+
+    expect(txs[2].to.toLowerCase()).toEqual(mockUserAirdropAddress)
   })
 
   it('do not claim investor airdrop while paused', () => {
@@ -93,6 +207,7 @@ describe('createClaimTxs', () => {
       investorClaimable: parseEther('100').toString(),
       isMax: false,
       userClaimable: '0',
+      sep5Claimable: '0',
       isTokenPaused: true,
     })
 
@@ -127,6 +242,7 @@ describe('createClaimTxs', () => {
       investorClaimable: parseEther('100').toString(),
       isMax: false,
       userClaimable: '0',
+      sep5Claimable: '0',
       isTokenPaused: false,
     })
 

--- a/src/utils/airdrop.ts
+++ b/src/utils/airdrop.ts
@@ -4,33 +4,60 @@ import { parseEther } from 'ethers/lib/utils'
 const MAX_UINT128 = BigNumber.from('0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF')
 
 /**
- * Splits the amount the user wants to claim into user airdrop and ecosystem airdrop.
- * @returns userAmount in Wei, investorAmount in Wei, ecosystemAmount in Wei
+ * Splits the amount the user wants to claim into user airdrop, SEP5 airdrop and ecosystem airdrop.
+ * @returns sep5Amount in Wei, userAmount in Wei, investorAmount in Wei, ecosystemAmount in Wei
  */
-export const splitAirdropAmounts = (
-  isMaxAmountSelected: boolean,
-  amount: string,
-  userAirdropClaimable: string,
-  investorClaimable: string,
-): [string, string, string] => {
-  if (isMaxAmountSelected) {
-    return [MAX_UINT128.toString(), MAX_UINT128.toString(), MAX_UINT128.toString()]
+export const splitAirdropAmounts = ({
+  isMax,
+  amount: claim,
+  sep5AirdropClaimable,
+  userAirdropClaimable,
+  investorClaimable,
+}: {
+  isMax: boolean
+  amount: string
+  sep5AirdropClaimable: string
+  userAirdropClaimable: string
+  investorClaimable: string
+}): [
+  string, // SEP5
+  string, // User
+  string, // Investor
+  string, // Ecosystem
+] => {
+  if (isMax) {
+    return [MAX_UINT128.toString(), MAX_UINT128.toString(), MAX_UINT128.toString(), MAX_UINT128.toString()]
   }
 
-  const amountInWei = parseEther(amount)
+  const amountInWei = parseEther(claim)
 
-  if (amountInWei.gt(BigNumber.from(userAirdropClaimable))) {
-    const leftOver = amountInWei.sub(BigNumber.from(userAirdropClaimable))
+  const sep5 = BigNumber.from(sep5AirdropClaimable)
 
-    if (leftOver.gt(BigNumber.from(investorClaimable))) {
-      // We claim full user and investor airdrop + part leftOver of ecosystem
-      return [userAirdropClaimable, investorClaimable, leftOver.sub(BigNumber.from(investorClaimable)).toString()]
-    } else {
-      // We claim full user + leftOver of investor airdrop
-      return [userAirdropClaimable, leftOver.toString(), '0']
-    }
+  // We must claim from SEP5 first in case the selected amount is below that of the pre-SEP5 allocation
+  if (amountInWei.lte(sep5)) {
+    return [amountInWei.toString(), '0', '0', '0']
   }
 
-  // We just claim the user airdrop
-  return [amountInWei.toString(), '0', '0']
+  const user = BigNumber.from(userAirdropClaimable)
+  const userAndSep5 = sep5.add(user)
+
+  if (amountInWei.lte(userAndSep5)) {
+    const leftOver = amountInWei.sub(sep5)
+    return [sep5AirdropClaimable, leftOver.toString(), '0', '0']
+  }
+
+  const investor = BigNumber.from(investorClaimable)
+  const userAndSep5AndInvestor = userAndSep5.add(investor)
+
+  if (amountInWei.lte(userAndSep5AndInvestor)) {
+    const leftOver = amountInWei.sub(userAndSep5)
+    return [sep5AirdropClaimable, userAirdropClaimable, leftOver.toString(), '0']
+  }
+
+  return [
+    sep5AirdropClaimable,
+    userAirdropClaimable,
+    investorClaimable,
+    amountInWei.sub(userAndSep5AndInvestor).toString(),
+  ]
 }

--- a/src/utils/vesting.ts
+++ b/src/utils/vesting.ts
@@ -46,11 +46,13 @@ export const calculateVestedAmount = (vestingClaim: Vesting): string => {
 
 export const getVestingTypes = (vestingData: Vesting[]) => {
   const userVesting = vestingData?.find((vesting) => vesting.tag === 'user') ?? null
+  const sep5Vesting = vestingData?.find((vesting) => vesting.tag === 'user_v2') ?? null
   const ecosystemVesting = vestingData?.find((vesting) => vesting.tag === 'ecosystem') ?? null
   const investorVesting = vestingData?.find((vesting) => vesting.tag === 'investor') ?? null
 
   return {
     userVesting,
+    sep5Vesting,
     ecosystemVesting,
     investorVesting,
   }


### PR DESCRIPTION
## What it solves

Resolves SEP #5 contract interaction

## How this PR fixes it

This integrates with a test airdrop contract `0xB1E81Fe4442FA5A0eE38feB7146E547937C6E737`, allocating `69` tokens to `0x5f310dc66F4ecDE9a1769f1B7D75224dA592201e`. All claims are batched with the test contract first to ensure redemptions for SEP #5.

The [above allocation is pushed to the current data locally](https://github.com/safe-global/safe-dao-governance-app/blob/2cb2b3f64e01f7d07ce623c74513a543fb963370/src/hooks/useAllocations.ts#L21-L32) if the Safe is being used with the app. It replaces all previously static mock data in the interface.

## How to test it

1. Open the `0x5f310dc66F4ecDE9a1769f1B7D75224dA592201e` Safe in two windows.
2. Add this PR deployment as a custom Safe App in one.
3. Add the dev deployment (`https://safe-dao-governance.dev.5afe.dev`) as a custom Safe App in the other.
4. Observe the higher allocation (of 69 value) in the PR deployment.
5. Claim the same amount of tokens in both windows and observe the PR deployment transaction modal showing the test contract above that of the old one.

## Screenshots

![image](https://github.com/safe-global/safe-dao-governance-app/assets/20442784/dc65b15f-633a-4714-91cd-54b230bf35e2)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
