### PR TITLE
[EPIC] SEP #5 - Live claiming data test

### DIFF
--- a/src/hooks/useAllocations.ts
+++ b/src/hooks/useAllocations.ts
@@ -3,7 +3,6 @@ import useSWRImmutable from 'swr/immutable'
 import { AIRDROP_TAGS, VESTING_URL } from '@/config/constants'
 import { useAddress } from '@/hooks/useAddress'
 import { useChainId } from '@/hooks/useChainId'
-import { sameAddress } from '@/utils/addresses'
 
 type Tags = (typeof AIRDROP_TAGS)[keyof typeof AIRDROP_TAGS]
 

--- a/src/hooks/useAllocations.ts
+++ b/src/hooks/useAllocations.ts
@@ -20,19 +20,6 @@ export type Allocation = {
   proof: string[]
 }
 
-const MOCK_SEP5_ALLOCATION: Allocation = {
-  tag: 'user_v2',
-  account: '0x5f310dc66F4ecDE9a1769f1B7D75224dA592201e',
-  chainId: 5,
-  contract: '0xf7ec19587A59af367924c301C9b25A02A0BA6b73',
-  vestingId: '0x2347bdc1bab409abe9d16809086a3bad5c5462f3fa20754f017486e031f6df73',
-  durationWeeks: 208,
-  startDate: 1662026400,
-  amount: '0x03c3656232739e0000',
-  curve: 0,
-  proof: [],
-}
-
 const fetchAllocation = async (chainId: string, address: string): Promise<Allocation[]> => {
   try {
     const response = await fetch(`${VESTING_URL}/${chainId}/${address}.json`)
@@ -48,17 +35,7 @@ const fetchAllocation = async (chainId: string, address: string): Promise<Alloca
     }
 
     // Success
-    const allocations: Allocation[] = await response.json()
-
-    // TODO: Remove mock allocation when vesting is deployed
-    const isCurrentChain = MOCK_SEP5_ALLOCATION.chainId.toString() === chainId
-    const isCurrentAddress = sameAddress(MOCK_SEP5_ALLOCATION.account, address)
-
-    if (isCurrentChain && isCurrentAddress) {
-      allocations.push(MOCK_SEP5_ALLOCATION)
-    }
-
-    return allocations
+    return response.json() as Promise<Allocation[]>
   } catch (err) {
     throw Error(`Error fetching vestings: ${err}`)
   }


### PR DESCRIPTION
## What it solves

Removes local mocks

## How this PR fixes it

As the "final" claiming data [has been verified locally](https://github.com/safe-global/safe-dao-governance-app/pull/41#issuecomment-1628694240), this removes the reliance on local mock data.

This instead fetches the deployed claiming app data.

Note: the claiming data [has since been updated](https://github.com/safe-global/claiming-app-data/commit/50b251bf8c49b9937fc5d268e44548f66240e06f) to accomodate for a redemption deadline (18.07).

## How to test it

Open a Safe that is part of the test data claim from the test airdrop successfully.


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
