### PR TITLE
fix: timezone + spelling mistake

### DIFF
--- a/src/components/Claim/steps/ClaimOverview/index.tsx
+++ b/src/components/Claim/steps/ClaimOverview/index.tsx
@@ -164,7 +164,7 @@ const ClaimOverview = ({ onNext }: { onNext: (data: ClaimFlow) => void }): React
             <InfoAlert>
               <Typography variant="body2">
                 Execute at least one claim of any amount of your allocation before {SEP5_EXPIRATION} otherwise it will
-                be transferred back to the Safe{`{DAO}`} treasurary.
+                be transferred back to the Safe{`{DAO}`} treasury.
               </Typography>
             </InfoAlert>
           </Grid>

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -54,7 +54,7 @@ export const GUARDIANS_IMAGE_URL = `${CLAIMING_DATA_URL}/guardians/images`
 export const VESTING_URL = `${CLAIMING_DATA_URL}/allocations`
 
 export const SEP5_EXPIRATION_DATE = '27.10.2023'
-export const SEP5_EXPIRATION = `${SEP5_EXPIRATION_DATE} 10:00 CET`
+export const SEP5_EXPIRATION = `${SEP5_EXPIRATION_DATE} 10:00 UTC`
 
 export const AIRDROP_TAGS = {
   USER: 'user',


### PR DESCRIPTION
## What it solves

Resolves #45

## How this PR fixes it

The spelling mistake of "treasury" on the claim overview has been fixed, as well as the timezone to "UTC".

## How to test it

Open the claim overview screen and observe the above fixes.

## Screenshots

![image](https://github.com/safe-global/safe-dao-governance-app/assets/20442784/12f6a646-0701-4db4-ab0e-cf73ec31cbc5)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
