### PR TITLE
fix: memoize redemption, future-proof SEP5 check, prevent balance crash

### DIFF
--- a/src/hooks/useSafeTokenAllocation.ts
+++ b/src/hooks/useSafeTokenAllocation.ts
@@ -3,6 +3,7 @@ import { BigNumber } from 'ethers'
 import { defaultAbiCoder } from 'ethers/lib/utils'
 import useSWR from 'swr'
 import { useRouter } from 'next/router'
+import memoize from 'lodash/memoize'
 import type { JsonRpcProvider } from '@ethersproject/providers'
 
 import { getAirdropInterface } from '@/services/contracts/Airdrop'
@@ -23,6 +24,16 @@ export type Vesting = Allocation & {
 }
 
 const airdropInterface = getAirdropInterface()
+
+export const _getRedeemDeadline = memoize(
+  async (allocation: Allocation, provider: JsonRpcProvider): Promise<string> => {
+    return provider.call({
+      to: allocation.contract,
+      data: airdropInterface.encodeFunctionData('redeemDeadline'),
+    })
+  },
+  ({ chainId, contract }) => chainId + contract,
+)
 
 /**
  * Add on-chain information to allocation.
@@ -52,10 +63,7 @@ const completeAllocation = async (allocation: Allocation, provider: JsonRpcProvi
   }
 
   // Allocation is not yet redeemed => check the redeemDeadline
-  const redeemDeadline = await provider.call({
-    to: allocation.contract,
-    data: airdropInterface.encodeFunctionData('redeemDeadline'),
-  })
+  const redeemDeadline = _getRedeemDeadline(allocation, provider)
 
   const redeemDeadlineDate = new Date(BigNumber.from(redeemDeadline).mul(1000).toNumber())
 

--- a/src/hooks/useSafeTokenAllocation.ts
+++ b/src/hooks/useSafeTokenAllocation.ts
@@ -112,7 +112,7 @@ const computeVotingPower = (validVestingData: Vesting[], balance: string): BigNu
   )
 
   // add balance
-  return tokensInVesting.add(balance || '0')
+  return tokensInVesting.add(BigNumber.from(balance))
 }
 
 export const _getVotingPower = async ({

--- a/src/hooks/useSafeTokenAllocation.ts
+++ b/src/hooks/useSafeTokenAllocation.ts
@@ -63,7 +63,7 @@ const completeAllocation = async (allocation: Allocation, provider: JsonRpcProvi
   }
 
   // Allocation is not yet redeemed => check the redeemDeadline
-  const redeemDeadline = _getRedeemDeadline(allocation, provider)
+  const redeemDeadline = await _getRedeemDeadline(allocation, provider)
 
   const redeemDeadlineDate = new Date(BigNumber.from(redeemDeadline).mul(1000).toNumber())
 

--- a/src/utils/airdrop.ts
+++ b/src/utils/airdrop.ts
@@ -72,5 +72,5 @@ export const canRedeemSep5Airdrop = (allocation: ReturnType<typeof useSafeTokenA
     return false
   }
 
-  return !sep5Allocation.isRedeemed
+  return !sep5Allocation.isRedeemed && !sep5Allocation.isExpired
 }


### PR DESCRIPTION
## What it solves

Copies logic from `safe-wallet-web` for redemption memoization, SEP5 qualification and balance calculation.

## How this PR fixes it

This copies over the [memoization logic for the redemption date](https://github.com/safe-global/safe-wallet-web/pull/2411), as well as the [deadline check improvement for SEP5 claiming ability](https://github.com/safe-global/safe-wallet-web/pull/2472#discussion_r1309928840) and [balance crash fix](https://github.com/safe-global/safe-wallet-web/pull/2476).

## How to test it

Safes that qualify for SEP5 should function as before.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
