### PR TITLE
Fix unsafe expression usage

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -19,10 +19,12 @@ jobs:
       - name: Extract version
         if: github.event.pull_request.merged == true
         id: version
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           NEW_VERSION=$(node -p 'require("./package.json").version')
           echo "version=v$NEW_VERSION" >> $GITHUB_OUTPUT
-          echo "${{ github.event.pull_request.body }}" > CHANGELOG.md
+          echo "$PR_BODY" > CHANGELOG.md
 
       - name: Create a git tag
         if: github.event.pull_request.merged == true


### PR DESCRIPTION
Just creating a PR instead of trying to report this privately since the only way to exploit this would be to submit a PR, have it approved, and edit the PR description with an injection payload that no one notices before clicking merge.

**Reference:**

* https://www.praetorian.com/blog/pwn-request-hacking-microsoft-github-repositories-and-more/