### PR TITLE
Fix: error handling for locking / unlocking and withdrawal

### DIFF
--- a/src/components/TockenUnlocking/UnlockTokenWidget.tsx
+++ b/src/components/TockenUnlocking/UnlockTokenWidget.tsx
@@ -4,7 +4,17 @@ import SafeToken from '@/public/images/token.svg'
 import { getBoostFunction, getTimeFactor, getTokenBoost, LockHistory } from '@/utils/boost'
 import { formatAmount } from '@/utils/formatters'
 import css from './styles.module.css'
-import { Box, Stack, Grid, Typography, TextField, InputAdornment, Button, Divider } from '@mui/material'
+import {
+  Box,
+  Stack,
+  Grid,
+  Typography,
+  TextField,
+  InputAdornment,
+  Button,
+  Divider,
+  CircularProgress,
+} from '@mui/material'
 import { formatUnits, parseUnits } from 'ethers/lib/utils'
 import BoostCounter from '../BoostCounter'
 import { BoostGraph } from '../TokenLocking/BoostGraph/BoostGraph'
@@ -24,6 +34,9 @@ export const UnlockTokenWidget = ({
 }) => {
   const [unlockAmount, setUnlockAmount] = useState('0')
   const [unlockAmountError, setUnlockAmountError] = useState<string>()
+
+  const [isUnlocking, setIsUnlocking] = useState(false)
+
   const chainId = useChainId()
   const { sdk } = useSafeAppsSDK()
   const theme = useTheme()
@@ -62,8 +75,15 @@ export const UnlockTokenWidget = ({
   }, [currentlyLocked])
 
   const onUnlock = async () => {
+    setIsUnlocking(true)
     const unlockTx = createUnlockTx(chainId, parseUnits(unlockAmount, 18))
-    await sdk.txs.send({ txs: [unlockTx] })
+
+    try {
+      await sdk.txs.send({ txs: [unlockTx] })
+    } catch (err) {
+      console.error(err)
+    }
+    setIsUnlocking(false)
   }
 
   return (
@@ -115,9 +135,9 @@ export const UnlockTokenWidget = ({
                 variant="contained"
                 fullWidth
                 disableElevation
-                disabled={Boolean(unlockAmountError)}
+                disabled={Boolean(unlockAmountError) || isUnlocking}
               >
-                Unlock
+                {isUnlocking ? <CircularProgress size={20} /> : 'Unlock'}
               </Button>
             </Grid>
           </Grid>

--- a/src/components/TockenUnlocking/WinthdrawStats.tsx
+++ b/src/components/TockenUnlocking/WinthdrawStats.tsx
@@ -19,7 +19,6 @@ export const WithdrawStats = ({
   nextUnlock: SingleUnlock | undefined
   loading: boolean
 }) => {
-  const unlockedReady = nextUnlock?.isUnlocked ? nextUnlock.unlockAmount : BigNumber.from(0)
   const nextUnlockAmount = nextUnlock ? Number(formatUnits(nextUnlock?.unlockAmount, 18)) : 0
 
   const timeToUnlock =

--- a/src/components/TockenUnlocking/index.tsx
+++ b/src/components/TockenUnlocking/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Link, Stack } from '@mui/material'
+import { Box, Button, CircularProgress, Link, Stack } from '@mui/material'
 
 import NextLink from 'next/link'
 import { AppRoutes } from '@/config/routes'
@@ -13,6 +13,7 @@ import { UnlockStats } from './UnlockStats'
 import { WithdrawStats } from './WinthdrawStats'
 import { UnlockTokenWidget } from './UnlockTokenWidget'
 import { useLockHistory } from '@/hooks/useLockHistory'
+import { useState } from 'react'
 
 const TokenUnlocking = () => {
   const { isLoading: userLockingInfosLoading, data: userLockingInfos } = useSafeUserLockingInfos()
@@ -25,9 +26,14 @@ const TokenUnlocking = () => {
   const nextUnlock = userLockingInfos?.nextUnlock
   const unlockedReady = nextUnlock?.isUnlocked ? nextUnlock.unlockAmount : BigNumber.from(0)
 
+  const [isWithdrawing, setIsWithdrawing] = useState(false)
+
   const onWithdraw = async () => {
+    setIsWithdrawing(true)
     const withdrawTx = createWithdrawTx(chainId)
     await sdk.txs.send({ txs: [withdrawTx] })
+
+    setIsWithdrawing(false)
   }
 
   return (
@@ -53,8 +59,13 @@ const TokenUnlocking = () => {
           nextUnlock={nextUnlock}
         />
         <Box>
-          <Button variant="contained" color="primary" onClick={onWithdraw} disabled={unlockedReady.eq(0)}>
-            Withdraw
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={onWithdraw}
+            disabled={unlockedReady.eq(0) || isWithdrawing}
+          >
+            {isWithdrawing ? <CircularProgress size={20} /> : 'Withdraw'}
           </Button>
         </Box>
       </PaperContainer>

--- a/src/components/TokenLocking/LockTokenWidget.tsx
+++ b/src/components/TokenLocking/LockTokenWidget.tsx
@@ -1,5 +1,17 @@
 import { formatAmount } from '@/utils/formatters'
-import { Chip, Typography, Stack, Grid, TextField, InputAdornment, Skeleton, Button, Box, Divider } from '@mui/material'
+import {
+  Chip,
+  Typography,
+  Stack,
+  Grid,
+  TextField,
+  InputAdornment,
+  Skeleton,
+  Button,
+  Box,
+  Divider,
+  CircularProgress,
+} from '@mui/material'
 import { formatUnits, parseUnits } from 'ethers/lib/utils'
 import SafeToken from '@/public/images/token.svg'
 
@@ -30,6 +42,8 @@ export const LockTokenWidget = ({ safeBalance }: { safeBalance: BigNumberish | u
   const [amount, setAmount] = useState('0')
 
   const [amountError, setAmountError] = useState<string | undefined>(undefined)
+
+  const [isLocking, setIsLocking] = useState(false)
 
   const debouncedAmount = useDebounce(amount, 1000, '0')
   const cleanedAmount = useMemo(() => (debouncedAmount.trim() === '' ? '0' : debouncedAmount.trim()), [debouncedAmount])
@@ -68,9 +82,15 @@ export const LockTokenWidget = ({ safeBalance }: { safeBalance: BigNumberish | u
   }, [safeBalance])
 
   const onLockTokens = async () => {
+    setIsLocking(true)
     const approveTx = createApproveTx(chainId, parseUnits(amount, 18))
     const lockTx = createLockTx(chainId, parseUnits(amount, 18))
-    await sdk.txs.send({ txs: [approveTx, lockTx] })
+    try {
+      await sdk.txs.send({ txs: [approveTx, lockTx] })
+    } catch (error) {
+      console.error(error)
+    }
+    setIsLocking(false)
   }
 
   return (
@@ -129,9 +149,9 @@ export const LockTokenWidget = ({ safeBalance }: { safeBalance: BigNumberish | u
                   variant="contained"
                   fullWidth
                   disableElevation
-                  disabled={Boolean(amountError)}
+                  disabled={Boolean(amountError) || isLocking}
                 >
-                  Lock
+                  {isLocking ? <CircularProgress size={20} /> : 'Lock'}
                 </Button>
               </Grid>
             </Grid>


### PR DESCRIPTION
Errors around transaction execution were not caught.

To test:
- Create a lock / unlock or withdraw transaction
- Abort the signing
- Observe there is no more uncaught error