### PR TITLE
Feat: change styles for `remove SAFE from locking button` to match Figma

### DIFF
--- a/src/components/TokenLocking/ActionNavigation.tsx
+++ b/src/components/TokenLocking/ActionNavigation.tsx
@@ -25,30 +25,18 @@ export const ActionNavigation = () => {
 
   const onUnlockAndWithdraw = onNavigate(AppRoutes.unlock)
   return (
-    <Grid container direction="row" spacing={3}>
-      <Grid item xs={8}>
-        <Box className={`${css.bordered}`} padding={3}>
-          <Typography variant="subtitle1" fontWeight={700}>
-            Some call for action
-          </Typography>
-          <Typography variant="body2">Some subtitle</Typography>
-        </Box>
-      </Grid>
-      <Grid item xs={4}>
-        <Stack>
-          <Button
-            variant="outlined"
-            color="secondary"
-            onClick={onUnlockAndWithdraw}
-            sx={{ borderWidth: '1px !important' }}
-          >
-            <Box display="flex" flexDirection="row" justifyContent="space-between" alignItems="center" width="100%">
-              <Box>Unlock & Withdraw</Box>
-              <ChevronRight fontSize="medium" />
-            </Box>
-          </Button>
-        </Stack>
-      </Grid>
-    </Grid>
+    <Stack>
+      <Box className={`${css.bordered}`} display="flex" justifyContent="space-between" alignItems="center" padding={3}>
+        <Typography variant="subtitle1" fontWeight={700}>
+          Remove SAFE from locking
+        </Typography>
+
+        <Button variant="outlined" color="primary" onClick={onUnlockAndWithdraw} sx={{ borderWidth: '1px !important' }}>
+          <Box display="flex" alignItems="center">
+            <Box>Unlock/Withdraw</Box>
+          </Box>
+        </Button>
+      </Box>
+    </Stack>
   )
 }


### PR DESCRIPTION

After changes:
<img width="893" alt="image" src="https://github.com/safe-global/safe-dao-governance-app/assets/17801424/cc3e3349-8227-4d17-ae14-0984211ad25a">
