### PR TITLE
Fix: initial token amount is zero

### DIFF
--- a/src/hooks/useSafeTokenBalance.ts
+++ b/src/hooks/useSafeTokenBalance.ts
@@ -12,7 +12,7 @@ export const useSafeTokenBalance = () => {
   const chainId = useChainId()
   const address = useAddress()
 
-  return useSWR(web3 ? QUERY_KEY : null, () => {
+  return useSWR(web3 && address ? QUERY_KEY : null, () => {
     if (!address || !web3) {
       return '0'
     }


### PR DESCRIPTION
## What this fixes
- The query cached a 0 if the address was undefined on the first load until the window got focused again

## How this PR fixes it
- Only gives a Query key for the balance query once the address is available