### PR TITLE
fix: Use Math.floor instead of Math.round for the boost UI

### DIFF
--- a/src/components/BoostCounter/index.tsx
+++ b/src/components/BoostCounter/index.tsx
@@ -16,11 +16,6 @@ const digitRotations: Record<number, number> = {
   [5]: Math.random() * 6 - 3,
 }
 
-const roundNumber = (num: number, digits: number) => {
-  const decimal = Math.pow(10, digits)
-  return Math.round(num * decimal) / decimal
-}
-
 const BoostCounter = ({
   value,
   direction,
@@ -66,7 +61,7 @@ const BoostCounter = ({
       ) {
         rotationRef.current = digitRotations[floorNumber(newNumber, 0)]
       }
-      setCurrentNumber(roundNumber(newNumber, 3))
+      setCurrentNumber(floorNumber(newNumber, 3))
 
       if (elapsed < DURATION && targetRef.current === target) {
         requestAnimationFrame(tick)


### PR DESCRIPTION
Fixes [Notion](https://www.notion.so/safe-global/5300d6ffcb2043cc9e7fcd10bf14dff5?v=97acdfbecf184482a82449013cc519e9&p=e4b0580199c340b5b7be9f12d2e7f3ec&pm=s)

## How to test

Choose a lock amount so that the graph shows a 1,99x or 2,99x etc. value and observe the same number is visible to the right

## Screenshots

<img width="862" alt="Screenshot 2024-03-27 at 13 58 34" src="https://github.com/safe-global/safe-dao-governance-app/assets/5880855/debd6d1a-b746-4578-94de-22bc04357c60">
<img width="856" alt="Screenshot 2024-03-27 at 13 58 43" src="https://github.com/safe-global/safe-dao-governance-app/assets/5880855/c2f19b18-6ff7-4439-8d93-ec5cdd8ec473">
