### PR TITLE
Feat: Use dynamic value for users rank in activity rewards info banner

### DIFF
--- a/src/components/TokenLocking/ActivityRewardsInfo.tsx
+++ b/src/components/TokenLocking/ActivityRewardsInfo.tsx
@@ -8,6 +8,7 @@ import { ReactNode } from 'react'
 import Diamond from '@/public/images/diamond.png'
 import StarIcon from '@/public/images/star.svg'
 import Image from 'next/image'
+import { useOwnRank } from '@/hooks/useLeaderboard'
 
 const JUNE_10_TIMESTAMP = 1718013600000
 const SEPTEMBER_10_TIMESTAMP = 1725962400000
@@ -47,9 +48,11 @@ const Step = ({
   )
 }
 
-export const PlaceholderTopRight = () => {
+export const ActivityRewardsInfo = () => {
   const chainId = useChainId()
   const today = Date.now()
+  const ownRankResult = useOwnRank()
+  const { data: ownRank } = ownRankResult
 
   const stepsActive = [
     today >= CHAIN_START_TIMESTAMPS[chainId],
@@ -62,12 +65,16 @@ export const PlaceholderTopRight = () => {
   return (
     <>
       <div className={css.steps}>
-        <Typography variant="overline" fontWeight="bold" color="text.secondary" mb="6px">
-          Your current ranking
-        </Typography>
-        <Typography variant="h3" fontWeight="bold" display="flex" alignItems="center" gap={1}>
-          <SvgIcon component={StarIcon} inheritViewBox />#{mockRanking}
-        </Typography>
+        {ownRank && (
+          <>
+            <Typography variant="overline" fontWeight="bold" color="text.secondary" mb="6px">
+              Your current ranking
+            </Typography>
+            <Typography variant="h3" fontWeight="bold" display="flex" alignItems="center" gap={1}>
+              <SvgIcon component={StarIcon} inheritViewBox />#{ownRank.position}
+            </Typography>
+          </>
+        )}
         <Typography variant="h1" fontWeight={700} mt="52px" mb="40px" maxWidth="60%" className={css.gradientText}>
           Interact with Safe and get rewards
         </Typography>

--- a/src/components/TokenLocking/Leaderboard.tsx
+++ b/src/components/TokenLocking/Leaderboard.tsx
@@ -53,7 +53,6 @@ const StyledTableRow = styled(TableRow)(({ theme }) => ({
 }))
 
 const HighlightedTableRow = styled(TableRow)(({ theme }) => ({
-  // hide last border
   '& td:first-child': {
     borderRadius: '6px 0 0 6px',
   },
@@ -72,8 +71,6 @@ const HighlightedTableRow = styled(TableRow)(({ theme }) => ({
   '& td:not(:last-child)': {
     borderRight: 'none !important',
   },
-
-  '& td:before': {},
 }))
 
 const StyledTable = styled(Table)(({ theme }) => ({

--- a/src/components/TokenLocking/index.tsx
+++ b/src/components/TokenLocking/index.tsx
@@ -4,7 +4,7 @@ import NextLink from 'next/link'
 import { Leaderboard } from './Leaderboard'
 import { CurrentStats } from './CurrentStats'
 import { LockTokenWidget } from './LockTokenWidget'
-import { PlaceholderTopRight } from './PlaceholderTopRight'
+import { ActivityRewardsInfo } from './ActivityRewardsInfo'
 import { ActionNavigation } from './ActionNavigation'
 import PaperContainer from '../PaperContainer'
 import Asterix from '@/public/images/asterix.svg'
@@ -49,7 +49,7 @@ const TokenLocking = () => {
               inheritViewBox
               sx={{ color: 'transparent', position: 'absolute', top: 0, right: 0, height: 'inherit', width: 'inherit' }}
             />
-            <PlaceholderTopRight />
+            <ActivityRewardsInfo />
           </PaperContainer>
         </Stack>
       </Grid>


### PR DESCRIPTION
Solves: https://www.notion.so/safe-global/Replace-mock-ranking-with-real-rank-ac5377da44994933926be574497e021f?pvs=4

- Display the users rank instead of a placeholder.
- Show nothing if the user does not have a rank yet.
- Also, rename the component from PlaceholderTopRight -> ActivityRewardsInfo