### PR TITLE
Fix: align heights of right and left activity components

### DIFF
--- a/src/components/TokenLocking/ActivityRewardsInfo.tsx
+++ b/src/components/TokenLocking/ActivityRewardsInfo.tsx
@@ -1,4 +1,4 @@
-import { Divider, Link, Stack, SvgIcon, Typography } from '@mui/material'
+import { Chip, Divider, Link, Stack, SvgIcon, Typography } from '@mui/material'
 import css from './styles.module.css'
 import clsx from 'clsx'
 import ClockIcon from '@/public/images/clock-alt.svg'

--- a/src/components/TokenLocking/index.tsx
+++ b/src/components/TokenLocking/index.tsx
@@ -42,12 +42,12 @@ const TokenLocking = () => {
       </Grid>
 
       <Grid item xs={4}>
-        <Stack spacing={3}>
-          <PaperContainer sx={{ position: 'relative', overflow: 'hidden' }}>
+        <Stack spacing={3} justifyContent="stretch" height="100%">
+          <PaperContainer sx={{ position: 'relative', overflow: 'hidden', height: '100%' }}>
             <SvgIcon
               component={Asterix}
               inheritViewBox
-              sx={{ color: 'transparent', position: 'absolute', top: 0, right: 0, height: 'inherit', width: 'inherit' }}
+              sx={{ color: 'transparent', position: 'absolute', top: 0, right: 0, height: '208px', width: 'inherit' }}
             />
             <ActivityRewardsInfo />
           </PaperContainer>


### PR DESCRIPTION
## What this PR changes
- Makes the right side stretch to 100% height

## Screenshot
![Screenshot 2024-03-28 at 11 57 21](https://github.com/safe-global/safe-dao-governance-app/assets/2670790/8e453751-6739-4382-899e-37d6b4fc18cb)
