### PR TITLE
Feat: poll lock history and token balance

### DIFF
--- a/src/hooks/useLeaderboard.ts
+++ b/src/hooks/useLeaderboard.ts
@@ -1,7 +1,6 @@
 import { useAddress } from './useAddress'
 import useSWR from 'swr'
-import { useMemo } from 'react'
-import { CGW_BASE_URL } from '@/config/constants'
+import { CGW_BASE_URL, POLLING_INTERVAL } from '@/config/constants'
 import { toCursorParam } from '@/utils/gateway'
 
 type LeaderboardEntry = {
@@ -36,6 +35,7 @@ export const useOwnRank = () => {
         }
       })
     },
+    { refreshInterval: POLLING_INTERVAL },
   )
 }
 
@@ -50,15 +50,19 @@ export const useGlobalLeaderboardPage = (limit: number, offset?: number) => {
     return `${CGW_BASE_URL}/v1/locking/leaderboard?${toCursorParam(limit, offset)}`
   }
 
-  const { data } = useSWR(getKey(limit, offset), async (url: string) => {
-    return await fetch(url).then((resp) => {
-      if (resp.ok) {
-        return resp.json() as Promise<LeaderboardPage>
-      } else {
-        throw new Error('Error fetching leaderboard.')
-      }
-    })
-  })
+  const { data } = useSWR(
+    getKey(limit, offset),
+    async (url: string) => {
+      return await fetch(url).then((resp) => {
+        if (resp.ok) {
+          return resp.json() as Promise<LeaderboardPage>
+        } else {
+          throw new Error('Error fetching leaderboard.')
+        }
+      })
+    },
+    { refreshInterval: POLLING_INTERVAL },
+  )
 
   return data
 }

--- a/src/hooks/useLockHistory.ts
+++ b/src/hooks/useLockHistory.ts
@@ -1,7 +1,7 @@
 import { useAddress } from './useAddress'
 import useSWRInfinite from 'swr/infinite'
 import { useMemo } from 'react'
-import { CGW_BASE_URL } from '@/config/constants'
+import { CGW_BASE_URL, POLLING_INTERVAL } from '@/config/constants'
 import { toCursorParam } from '@/utils/gateway'
 
 export type LockEvent = {
@@ -63,15 +63,21 @@ export const useLockHistory = () => {
     [address],
   )
 
-  const { data, size, setSize } = useSWRInfinite(getKey, async (url: string) => {
-    return await fetch(url).then((resp) => {
-      if (resp.ok) {
-        return resp.json() as Promise<LockingHistoryEventPage>
-      } else {
-        throw new Error('Error fetching lock history.')
-      }
-    })
-  })
+  const { data, size, setSize } = useSWRInfinite(
+    getKey,
+    async (url: string) => {
+      return await fetch(url).then((resp) => {
+        if (resp.ok) {
+          return resp.json() as Promise<LockingHistoryEventPage>
+        } else {
+          throw new Error('Error fetching lock history.')
+        }
+      })
+    },
+    {
+      refreshInterval: POLLING_INTERVAL,
+    },
+  )
 
   // We need to load everything
   if (data && data.length > 0) {

--- a/src/hooks/useSafeTokenBalance.ts
+++ b/src/hooks/useSafeTokenBalance.ts
@@ -5,6 +5,7 @@ import useSWR from 'swr'
 import { fetchTokenBalance, fetchTokenLockingAllowance } from '@/utils/safe-token'
 import { fetchLockedAmount, fetchUnlockData } from '@/utils/lock'
 import { BigNumber } from 'ethers'
+import { POLLING_INTERVAL } from '@/config/constants'
 
 export const useSafeTokenBalance = () => {
   const QUERY_KEY = 'safe-token-balance'
@@ -12,12 +13,18 @@ export const useSafeTokenBalance = () => {
   const chainId = useChainId()
   const address = useAddress()
 
-  return useSWR(web3 && address ? QUERY_KEY : null, () => {
-    if (!address || !web3) {
-      return '0'
-    }
-    return fetchTokenBalance(chainId, address, web3)
-  })
+  return useSWR(
+    web3 && address ? QUERY_KEY : null,
+    () => {
+      if (!address || !web3) {
+        return '0'
+      }
+      return fetchTokenBalance(chainId, address, web3)
+    },
+    {
+      refreshInterval: POLLING_INTERVAL,
+    },
+  )
 }
 
 export const useSafeTokenLockingAllowance = () => {


### PR DESCRIPTION
## What does this PR change?
Currently the history, leaderboard position and the token balance are only polled when the window gets focused.
This PR adds a refreshInterval to those endpoints.