### PR TITLE
fix: Only allow number inputs for claiming, locking, and unlocking fields

### DIFF
--- a/src/components/Claim/index.tsx
+++ b/src/components/Claim/index.tsx
@@ -41,6 +41,9 @@ import { getGovernanceAppSafeAppUrl } from '@/utils/safe-apps'
 import { useChainId } from '@/hooks/useChainId'
 
 const validateAmount = (amount: string, maxAmount: string) => {
+  if (isNaN(Number(amount))) {
+    return 'The value must be a number'
+  }
   return mustBeFloat(amount) || minMaxValue(0, maxAmount, amount) || maxDecimals(amount, 18)
 }
 
@@ -94,7 +97,7 @@ const ClaimOverview = (): ReactElement => {
 
   // Handlers
   const onChangeAmount = (event: ChangeEvent<HTMLInputElement>) => {
-    const error = validateAmount(amount || '0', totalClaimableAmountInEth)
+    const error = validateAmount(event.target.value || '0', totalClaimableAmountInEth)
     setAmount(event.target.value)
     setAmountError(error)
 

--- a/src/components/TockenUnlocking/UnlockTokenWidget.tsx
+++ b/src/components/TockenUnlocking/UnlockTokenWidget.tsx
@@ -52,7 +52,7 @@ export const UnlockTokenWidget = ({
   }
 
   const validateAmount = (newAmount: string) => {
-    if (!newAmount || isNaN(Number(newAmount))) {
+    if (isNaN(Number(newAmount))) {
       return 'The value must be a number'
     }
     const parsed = parseUnits(newAmount, 18)

--- a/src/components/TockenUnlocking/UnlockTokenWidget.tsx
+++ b/src/components/TockenUnlocking/UnlockTokenWidget.tsx
@@ -52,6 +52,9 @@ export const UnlockTokenWidget = ({
   }
 
   const validateAmount = (newAmount: string) => {
+    if (!newAmount || isNaN(Number(newAmount))) {
+      return 'The value must be a number'
+    }
     const parsed = parseUnits(newAmount, 18)
     if (parsed.gt(currentlyLocked ?? '0')) {
       return 'Amount exceeds locked tokens'

--- a/src/components/TokenLocking/LockTokenWidget.tsx
+++ b/src/components/TokenLocking/LockTokenWidget.tsx
@@ -74,6 +74,9 @@ export const LockTokenWidget = ({ safeBalance }: { safeBalance: BigNumberish | u
 
   const validateAmount = useCallback(
     (newAmount: string) => {
+      if (!newAmount || isNaN(Number(newAmount))) {
+        return 'The value must be a number'
+      }
       const parsed = parseUnits(newAmount, 18)
       if (parsed.gt(safeBalance ?? '0')) {
         return 'Amount exceeds balance'

--- a/src/components/TokenLocking/LockTokenWidget.tsx
+++ b/src/components/TokenLocking/LockTokenWidget.tsx
@@ -74,7 +74,7 @@ export const LockTokenWidget = ({ safeBalance }: { safeBalance: BigNumberish | u
 
   const validateAmount = useCallback(
     (newAmount: string) => {
-      if (!newAmount || isNaN(Number(newAmount))) {
+      if (isNaN(Number(newAmount))) {
         return 'The value must be a number'
       }
       const parsed = parseUnits(newAmount, 18)


### PR DESCRIPTION
After changes:
<img width="476" alt="image" src="https://github.com/safe-global/safe-dao-governance-app/assets/17801424/3af24b81-f5bd-4c33-b77d-6dc7b60bd67e">
