### PR TITLE
Fix: better handling of decimals in input and miles receipt

### DIFF
--- a/src/components/TockenUnlocking/UnlockTokenWidget.tsx
+++ b/src/components/TockenUnlocking/UnlockTokenWidget.tsx
@@ -17,6 +17,7 @@ import { LOCK_EVENTS } from '@/analytics/lockEvents'
 import { trackSafeAppEvent } from '@/utils/analytics'
 import MilesReceipt from '@/components/TokenLocking/MilesReceipt'
 import { useTxSender } from '@/hooks/useTxSender'
+import { formatAmount } from '@/utils/formatters'
 
 export const UnlockTokenWidget = ({
   lockHistory,
@@ -39,6 +40,11 @@ export const UnlockTokenWidget = ({
   const debouncedAmount = useDebounce(unlockAmount, 1000, '0')
   const cleanedAmount = useMemo(() => (debouncedAmount.trim() === '' ? '0' : debouncedAmount.trim()), [debouncedAmount])
 
+  const onCloseReceipt = () => {
+    setUnlockAmount('0')
+    setReceiptOpen(false)
+  }
+
   const currentBoostFunction = useMemo(() => getBoostFunction(todayInDays, 0, lockHistory), [todayInDays, lockHistory])
   const newBoostFunction = useMemo(
     () => getBoostFunction(todayInDays, -Number(cleanedAmount), lockHistory),
@@ -46,20 +52,25 @@ export const UnlockTokenWidget = ({
   )
 
   const onChangeUnlockAmount = (event: ChangeEvent<HTMLInputElement>) => {
-    const error = validateAmount(event.target.value || '0')
-    setUnlockAmount(event.target.value)
+    const newValue = event.target.value.replaceAll(',', '.')
+    const error = validateAmount(newValue || '0')
+    setUnlockAmount(newValue)
     setUnlockAmountError(error)
   }
 
-  const validateAmount = (newAmount: string) => {
-    if (isNaN(Number(newAmount))) {
-      return 'The value must be a number'
-    }
-    const parsed = parseUnits(newAmount, 18)
-    if (parsed.gt(currentlyLocked ?? '0')) {
-      return 'Amount exceeds locked tokens'
-    }
-  }
+  const validateAmount = useCallback(
+    (newAmount: string) => {
+      const numberAmount = Number(newAmount)
+      if (isNaN(numberAmount)) {
+        return 'The value must be a number'
+      }
+      const parsed = parseUnits(numberAmount.toString(), 18)
+      if (parsed.gt(currentlyLocked ?? '0')) {
+        return 'Amount exceeds your locked tokens.'
+      }
+    },
+    [currentlyLocked],
+  )
 
   const onSetToMax = useCallback(() => {
     if (!currentlyLocked) {
@@ -144,8 +155,8 @@ export const UnlockTokenWidget = ({
       </Grid>
       <MilesReceipt
         open={receiptOpen}
-        onClose={() => setReceiptOpen(false)}
-        amount={unlockAmount}
+        onClose={onCloseReceipt}
+        amount={formatAmount(unlockAmount, 0)}
         newFinalBoost={floorNumber(newBoostFunction({ x: SEASON2_START }), 2)}
         isUnlock
       />

--- a/src/components/TokenLocking/LockTokenWidget.tsx
+++ b/src/components/TokenLocking/LockTokenWidget.tsx
@@ -55,6 +55,11 @@ export const LockTokenWidget = ({ safeBalance }: { safeBalance: BigNumberish | u
 
   const [isLocking, setIsLocking] = useState(false)
 
+  const onCloseReceipt = () => {
+    setAmount('0')
+    setReceiptOpen(false)
+  }
+
   const debouncedAmount = useDebounce(amount, 1000, '0')
   const cleanedAmount = useMemo(() => (debouncedAmount.trim() === '' ? '0' : debouncedAmount.trim()), [debouncedAmount])
 
@@ -74,10 +79,11 @@ export const LockTokenWidget = ({ safeBalance }: { safeBalance: BigNumberish | u
 
   const validateAmount = useCallback(
     (newAmount: string) => {
-      if (isNaN(Number(newAmount))) {
+      const numberAmount = Number(newAmount)
+      if (isNaN(numberAmount)) {
         return 'The value must be a number'
       }
-      const parsed = parseUnits(newAmount, 18)
+      const parsed = parseUnits(numberAmount.toString(), 18)
       if (parsed.gt(safeBalance ?? '0')) {
         return 'Amount exceeds balance'
       }
@@ -87,9 +93,10 @@ export const LockTokenWidget = ({ safeBalance }: { safeBalance: BigNumberish | u
 
   const onChangeAmount = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
-      const error = validateAmount(event.target.value || '0')
+      const newValue = event.target.value.replaceAll(',', '.')
+      const error = validateAmount(newValue || '0')
 
-      setAmount(event.target.value)
+      setAmount(newValue)
       setAmountError(error)
     },
     [validateAmount],
@@ -210,8 +217,8 @@ export const LockTokenWidget = ({ safeBalance }: { safeBalance: BigNumberish | u
       </Stack>
       <MilesReceipt
         open={receiptOpen}
-        onClose={() => setReceiptOpen(false)}
-        amount={amount}
+        onClose={onCloseReceipt}
+        amount={formatAmount(amount, 0)}
         newFinalBoost={floorNumber(newBoostFunction({ x: SEASON2_START }), 2)}
       />
     </>


### PR DESCRIPTION
## What this PR changes
- allow typing "," and "." as decimal separator in input fields
- remove decimals from miles receipt (decimals of Safe tokens are irrelevant for the boost)