### PR TITLE
Fix: back navigation for governance app screens

### DIFF
--- a/src/components/EducationSeries/index.tsx
+++ b/src/components/EducationSeries/index.tsx
@@ -25,7 +25,7 @@ export const EducationSeries = (): ReactElement => {
     <Distribution key={1} onBack={prevStep} onNext={onNext} />,
     <SafeToken key={2} onBack={prevStep} onNext={onNext} />,
     <SafeDao key={3} onBack={prevStep} onNext={onNext} />,
-    <Disclaimer key={4} onBack={prevStep} onNext={() => router.push(AppRoutes.index)} />,
+    <Disclaimer key={4} onBack={prevStep} onNext={() => router.push(AppRoutes.governance)} />,
   ]
 
   const progress = ((step + 1) / steps.length) * 100

--- a/src/components/StepHeader/index.tsx
+++ b/src/components/StepHeader/index.tsx
@@ -9,7 +9,7 @@ export const StepHeader = ({ title }: { title: ReactNode }): ReactElement => {
   const router = useRouter()
 
   const onClose = () => {
-    router.push(AppRoutes.index)
+    router.push(AppRoutes.governance)
   }
 
   return (


### PR DESCRIPTION
## What this PR changes
- Navigation on close in StepHeader of governance part of app leads to governance page
- Navigation after finishing the educational series leads back to governance app