### PR TITLE
Fix: show an error when connected wallet is not a safe account

### DIFF
--- a/src/components/SplashScreen/index.tsx
+++ b/src/components/SplashScreen/index.tsx
@@ -70,7 +70,7 @@ export const SplashScreen = (): ReactElement => {
         return
       }
     } catch (error) {
-      setError('unknown error')
+      return
     } finally {
       setIsConnecting(false)
     }


### PR DESCRIPTION
https://www.notion.so/safe-global/WC-if-the-connection-for-the-EOA-is-not-available-we-should-inform-about-it-better-c2a3b6902317436ab69f016fb1dbc676?pvs=4

<img width="812" alt="image" src="https://github.com/safe-global/safe-dao-governance-app/assets/17801424/0568864d-e329-4ab5-8b3b-64a4723b3958">
