### PR TITLE
Fix: redirect to splash screen after disconnecting in the header on the standalone app

### DIFF
--- a/src/components/AccountCenter/index.tsx
+++ b/src/components/AccountCenter/index.tsx
@@ -11,18 +11,24 @@ import { useChain } from '@/hooks/useChain'
 import { WalletInfo, UNKNOWN_CHAIN_NAME } from '@/components/WalletInfo'
 import { EthHashInfo } from '@/components/EthHashInfo'
 import type { ConnectedWallet } from '@/hooks/useWallet'
+import { useIsSafeApp } from '@/hooks/useIsSafeApp'
+import { AppRoutes } from '@/config/routes'
+import { useRouter } from 'next/router'
 
 import css from './styles.module.css'
 
 const Popper = ({ wallet }: { wallet: ConnectedWallet }): ReactElement => {
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
   const onboard = useOnboard()
+  const router = useRouter()
+  const isSafeApp = useIsSafeApp()
 
   const chain = useChain()
   const connectedChain = chain?.chainId === wallet.chainId ? chain : undefined
 
   const handleDisconnect = () => {
     onboard?.disconnectWallet({ label: wallet.label })
+    if (!isSafeApp) router.push({ pathname: AppRoutes.splash })
   }
 
   const handleClick = (event: MouseEvent<HTMLButtonElement>) => {


### PR DESCRIPTION
https://www.notion.so/safe-global/Issue-Disconnect-wallet-state-in-the-stand-alone-app-is-not-implemented-00294fb635f24cdb9f53fbb3612a923a?pvs=4