### PR TITLE
Fix: rounding in BoostCounter

### DIFF
--- a/src/components/BoostCounter/index.tsx
+++ b/src/components/BoostCounter/index.tsx
@@ -80,9 +80,8 @@ const BoostCounter = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value])
 
-  const digit = floorNumber(currentNumber, 0)
-
-  const decimals = floorNumber(currentNumber, 2).toString().slice(2)
+  const digit = currentNumber.toString().slice(0, 1)
+  const decimals = currentNumber.toString().slice(2).slice(0, 2)
 
   return (
     <Box display="inline-flex" gap="4px" alignItems="center">

--- a/src/components/BoostCounter/index.tsx
+++ b/src/components/BoostCounter/index.tsx
@@ -81,6 +81,7 @@ const BoostCounter = ({
   }, [value])
 
   const digit = currentNumber.toString().slice(0, 1)
+  const localeSeparator = (1.1).toLocaleString().charAt(1)
   const decimals = currentNumber.toString().slice(2).slice(0, 2)
 
   return (
@@ -97,7 +98,7 @@ const BoostCounter = ({
       >
         {digit}
       </Typography>
-      <Typography {...props}>{decimals !== '' ? `,${decimals}x` : 'x'}</Typography>
+      <Typography {...props}>{decimals !== '' ? `${localeSeparator}${decimals}x` : 'x'}</Typography>
     </Box>
   )
 }


### PR DESCRIPTION
## What this PR changes
- Instead of rounding the number we just slice it in BoostCounter to avoid rounding issues caused by incorrect floating point math.