### PR TITLE
fix: ignore max button without any locked tokens

### DIFF
--- a/src/components/TockenUnlocking/UnlockTokenWidget.tsx
+++ b/src/components/TockenUnlocking/UnlockTokenWidget.tsx
@@ -7,7 +7,7 @@ import { BoostGraph } from '../TokenLocking/BoostGraph/BoostGraph'
 import { useDebounce } from '@/hooks/useDebounce'
 import { createUnlockTx, LockHistory } from '@/utils/lock'
 import { useState, useMemo, ChangeEvent, useCallback } from 'react'
-import { BigNumberish } from 'ethers'
+import { BigNumber, BigNumberish } from 'ethers'
 import { useChainId } from '@/hooks/useChainId'
 import { getCurrentDays } from '@/utils/date'
 import { CHAIN_START_TIMESTAMPS, SEASON2_START } from '@/config/constants'
@@ -77,7 +77,7 @@ export const UnlockTokenWidget = ({
   )
 
   const onSetToMax = useCallback(() => {
-    if (!currentlyLocked) {
+    if (!currentlyLocked || BigNumber.from(currentlyLocked).eq(0)) {
       return
     }
     setUnlockAmount(formatUnits(currentlyLocked, 18))


### PR DESCRIPTION
## What this PR changes
- Returns early in setMaxAmount for unlock if no tokens have been locked before