### PR TITLE
Fix: Skip continue step on splash screen after connecting a wallet

### DIFF
--- a/src/components/SplashScreen/index.tsx
+++ b/src/components/SplashScreen/index.tsx
@@ -79,6 +79,7 @@ export const SplashScreen = (): ReactElement => {
       return
     } finally {
       setIsConnecting(false)
+      onContinue()
     }
   }
 


### PR DESCRIPTION
On the standalone app, after connecting a wallet on the splash screen, go straight to the app instead of requiring an extra click.