### PR TITLE
Fix: infinite re-render on splash screen for standalone app

### DIFF
--- a/src/hooks/useIsSafeApp.ts
+++ b/src/hooks/useIsSafeApp.ts
@@ -1,11 +1,6 @@
-import { useIsomorphicLayoutEffect } from '@/hooks/useIsomorphicLayoutEffect'
-
-let isSafeApp = false
+import { useSafeAppsSDK } from '@safe-global/safe-apps-react-sdk'
 
 export const useIsSafeApp = (): boolean => {
-  useIsomorphicLayoutEffect(() => {
-    isSafeApp = typeof window !== 'undefined' && window.self !== window.top
-  }, [isSafeApp])
-
-  return isSafeApp
+  const { connected } = useSafeAppsSDK()
+  return connected
 }

--- a/src/hooks/useIsSafeApp.ts
+++ b/src/hooks/useIsSafeApp.ts
@@ -1,14 +1,11 @@
-import { useState } from 'react'
-
 import { useIsomorphicLayoutEffect } from '@/hooks/useIsomorphicLayoutEffect'
 
-export const useIsSafeApp = (): boolean => {
-  const [isSafeApp, setIsSafeApp] = useState(true)
+let isSafeApp = false
 
+export const useIsSafeApp = (): boolean => {
   useIsomorphicLayoutEffect(() => {
-    const isIframe = typeof window !== 'undefined' && window.self !== window.top
-    setIsSafeApp(isIframe)
-  }, [setIsSafeApp])
+    isSafeApp = typeof window !== 'undefined' && window.self !== window.top
+  }, [isSafeApp])
 
   return isSafeApp
 }


### PR DESCRIPTION
## What it solves
The splash screen was continuously redirecting back and forth from the splash screen to the main app. 

## How this PR fixes it
Only set the isSafeApp variable once to avoid re-renders
