### PR TITLE
Fix: do not redirect from splash screen when there is an error with the connection

### DIFF
--- a/src/components/SplashScreen/index.tsx
+++ b/src/components/SplashScreen/index.tsx
@@ -77,6 +77,7 @@ export const SplashScreen = (): ReactElement => {
       }
       onContinue()
     } catch (error) {
+      setError('Wallet connection failed.')
       return
     } finally {
       setIsConnecting(false)

--- a/src/components/SplashScreen/index.tsx
+++ b/src/components/SplashScreen/index.tsx
@@ -75,11 +75,11 @@ export const SplashScreen = (): ReactElement => {
         setError('Connected wallet must be a Safe')
         return
       }
+      onContinue()
     } catch (error) {
       return
     } finally {
       setIsConnecting(false)
-      onContinue()
     }
   }
 


### PR DESCRIPTION
## What it solves
Automatic redirect from the splash screen was still happening even when there was an error (connected wallet is not a safe)
https://www.notion.so/safe-global/WC-if-the-connection-for-the-EOA-is-not-available-we-should-inform-about-it-better-c2a3b6902317436ab69f016fb1dbc676?pvs=4

## How this PR fixes it
Only redirect if the connection is successful.