### PR TITLE
Fix: widgets in light mode

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -65,17 +65,20 @@ const App = ({
 }): ReactElement => {
   const { pathname, query } = useRouter()
 
+  // Workaround for dark mode widgets
+  const isDarkMode = query.theme ? query.theme !== 'light' : true
+
   useEffect(() => {
     if (typeof document !== 'undefined') {
-      document.documentElement.setAttribute('data-theme', 'dark')
+      document.documentElement.setAttribute('data-theme', isDarkMode ? 'dark' : 'light')
     }
-  }, [])
+  }, [isDarkMode])
 
   const theme = useMemo(() => {
     // Extend the theme with the CssVarsProvider
-    return extendMuiTheme(initTheme())
+    return extendMuiTheme(initTheme(isDarkMode))
     // Widgets don't navigate, so we need not worry about the query changing
-  }, [])
+  }, [isDarkMode])
 
   const page = <Component {...pageProps} />
 

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -50,13 +50,14 @@ declare module '@mui/material/Button' {
   }
 }
 
-const initTheme = () => {
-  const shadowColor = darkPalette.primary.light
+const initTheme = (darkMode: boolean) => {
+  const colors = darkMode ? darkPalette : palette
+  const shadowColor = colors.primary.light
 
   return createTheme({
     palette: {
-      mode: 'dark',
-      ...darkPalette,
+      mode: darkMode ? 'dark' : 'light',
+      ...colors,
     },
     spacing: base,
     shape: {
@@ -64,10 +65,10 @@ const initTheme = () => {
     },
     shadows: [
       'none',
-      `0 0 2px ${shadowColor}`,
-      `0 0 2px ${shadowColor}`,
-      `0 0 2px ${shadowColor}`,
-      `0 0 2px ${shadowColor}`,
+      darkMode ? `0 0 2px ${shadowColor}` : `0 1px 4px ${shadowColor}0a, 0 4px 10px ${shadowColor}14`,
+      darkMode ? `0 0 2px ${shadowColor}` : `0 1px 4px ${shadowColor}0a, 0 4px 10px ${shadowColor}14`,
+      darkMode ? `0 0 2px ${shadowColor}` : `0 2px 20px ${shadowColor}0a, 0 8px 32px ${shadowColor}14`,
+      darkMode ? `0 0 2px ${shadowColor}` : `0 8px 32px ${shadowColor}0a, 0 24px 60px ${shadowColor}14`,
       ...Array(20).fill('none'),
     ] as Shadows,
     typography: {


### PR DESCRIPTION
## What this PR fixes
- The governance widgets are now rendered in light or dark mode depending on the theme query parameter
- If no parameter is present we always use dark mode.

## Screenshot
![Screenshot 2024-04-16 at 11 18 33](https://github.com/safe-global/safe-dao-governance-app/assets/2670790/72ccbdd7-2aca-4788-99cd-80aaad97666a)
