### PR TITLE
Fix: Responsiveness bugs in leaderboard,  locking widget, and page titles

### DIFF
--- a/src/components/GovernanceAndClaiming/index.tsx
+++ b/src/components/GovernanceAndClaiming/index.tsx
@@ -20,6 +20,8 @@ import { useIsDelegationPending } from '@/hooks/usePendingDelegations'
 import ClaimOverview from '@/components/Claim'
 import PaperContainer from '@/components/PaperContainer'
 
+import css from './styles.module.css'
+
 export const GovernanceAndClaiming = (): ReactElement => {
   const router = useRouter()
   const isWrongChain = useIsWrongChain()
@@ -63,7 +65,7 @@ export const GovernanceAndClaiming = (): ReactElement => {
   }
   return (
     <Grid container spacing={3} direction="row">
-      <Grid item xs={12}>
+      <Grid item xs={12} className={css.pageTitle}>
         <Typography variant="h2">Claim SAFE tokens and engage in governance</Typography>
       </Grid>
 

--- a/src/components/GovernanceAndClaiming/styles.module.css
+++ b/src/components/GovernanceAndClaiming/styles.module.css
@@ -1,0 +1,5 @@
+@media (max-width: 899px) {
+  .pageTitle {
+    margin: 16px;
+  }
+}

--- a/src/components/TokenLocking/BoostGraph/ActionNavigation/styles.module.css
+++ b/src/components/TokenLocking/BoostGraph/ActionNavigation/styles.module.css
@@ -1,14 +1,16 @@
 .buttonContainer {
   display: flex;
   justify-content: space-between;
+  align-items: center;
   padding: 24px;
   gap: 8px;
   border-radius: 6px;
   border: var(--mui-palette-border-light) 1px solid;
 }
 
-@media (max-width: 899px) {
+@media (max-width: 600px) {
   .buttonContainer {
     flex-direction: column;
+    align-items: flex-start;
   }
 }

--- a/src/components/TokenLocking/Leaderboard.tsx
+++ b/src/components/TokenLocking/Leaderboard.tsx
@@ -208,7 +208,12 @@ export const Leaderboard = () => {
           <Typography variant="h2" fontWeight={700} sx={{ mr: '8px', display: 'inline' }}>
             Locking Leaderboard
           </Typography>
-          <Typography variant="subtitle1" fontSize="small" color="text.secondary" sx={{ my: '8px', fontSize: '14px' }}>
+          <Typography
+            variant="subtitle1"
+            fontSize="small"
+            color="text.secondary"
+            sx={{ my: '8px', fontSize: '14px', maxWidth: '60%' }}
+          >
             Higher ranking means higher chances to get rewards.
           </Typography>
         </Box>

--- a/src/components/TokenLocking/index.tsx
+++ b/src/components/TokenLocking/index.tsx
@@ -22,7 +22,7 @@ const TokenLocking = () => {
   return (
     <Grid container spacing={3} direction="row-reverse">
       <Grid item xs={12} mb={3} className={css.pageTitle}>
-        <Typography variant="h2">SAFE Activity Rewards</Typography>
+        <Typography variant="h2">{'Get rewards with Safe{Pass}'}</Typography>
       </Grid>
       <Grid item xs={12} lg={4} className={css.activityRewards}>
         <Stack spacing={3} justifyContent="stretch" height="100%">

--- a/src/components/TokenLocking/styles.module.css
+++ b/src/components/TokenLocking/styles.module.css
@@ -263,6 +263,10 @@
   .leftReceipt {
     border-bottom: 1px dashed white;
   }
+
+  .pageTitle {
+    margin: 16px;
+  }
 }
 
 .gradientBackground {


### PR DESCRIPTION
Fixes: https://www.notion.so/safe-global/Web-boards-44788b2920624e88a7d15da4754bfd10?p=ba8b018af5b64eb9b3bba327aa31acc5&pm=s

- center `Remove SAFE from locking ` text vertically.
<img width="564" alt="image" src="https://github.com/safe-global/safe-dao-governance-app/assets/17801424/1bbce9e3-37fa-4ee2-9fa9-a6b4f959e1cf"> 

After changes:

<img width="666" alt="image" src="https://github.com/safe-global/safe-dao-governance-app/assets/17801424/607fc748-7bd9-4f86-9443-6f328900ffd7">

- fix overlap of subtitle text in leaderboard:
![image](https://github.com/safe-global/safe-dao-governance-app/assets/17801424/e5a7ae50-a355-4b54-b644-dab8b49000a3)

- Add margin to titles on small screens: 
<img width="360" alt="image" src="https://github.com/safe-global/safe-dao-governance-app/assets/17801424/62c0cfe7-4bb1-49e5-ba7f-7532dd344ee9">
 

