### PR TITLE
Fix: open governance tab when clicking the widget

### DIFF
--- a/src/components/EnsureWalletConnection/index.tsx
+++ b/src/components/EnsureWalletConnection/index.tsx
@@ -17,5 +17,5 @@ export const EnsureWalletConnection = ({ children }: { children: ReactElement })
 
   const shouldRedirect = !web3 && isProviderRoute(router.pathname)
 
-  return shouldRedirect ? <Redirect url={AppRoutes.splash} /> : children
+  return shouldRedirect ? <Redirect url={AppRoutes.splash} query={{ next: router.pathname }} /> : children
 }

--- a/src/components/Redirect/index.tsx
+++ b/src/components/Redirect/index.tsx
@@ -1,16 +1,24 @@
 import { useRouter } from 'next/router'
-import type { UrlObject } from 'url'
 
 import { useIsomorphicLayoutEffect } from '@/hooks/useIsomorphicLayoutEffect'
+import { ParsedUrlQueryInput } from 'querystring'
 
-export const Redirect = ({ url, replace }: { url: string | UrlObject; replace?: boolean }): null => {
+export const Redirect = ({
+  url,
+  replace,
+  query,
+}: {
+  url: string
+  replace?: boolean
+  query?: ParsedUrlQueryInput
+}): null => {
   const router = useRouter()
 
   useIsomorphicLayoutEffect(() => {
     if (replace) {
       router.replace(url)
     } else {
-      router.push(url)
+      router.push({ pathname: url, query })
     }
   }, [replace, router, url])
 

--- a/src/components/SplashScreen/index.tsx
+++ b/src/components/SplashScreen/index.tsx
@@ -89,7 +89,8 @@ export const SplashScreen = (): ReactElement => {
   const onContinue = async () => {
     trackSafeAppEvent(NAVIGATION_EVENTS.OPEN_LOCKING.action, 'opening')
     alreadyVisitedStorage.set(true)
-    router.push(AppRoutes.activity)
+    const nextPage = router.query.next === '/governance' ? AppRoutes.governance : AppRoutes.activity
+    router.push(nextPage)
   }
 
   useIsomorphicLayoutEffect(() => {

--- a/src/components/SplashScreen/index.tsx
+++ b/src/components/SplashScreen/index.tsx
@@ -89,7 +89,7 @@ export const SplashScreen = (): ReactElement => {
   const onContinue = async () => {
     trackSafeAppEvent(NAVIGATION_EVENTS.OPEN_LOCKING.action, 'opening')
     alreadyVisitedStorage.set(true)
-    const nextPage = router.query.next === '/governance' ? AppRoutes.governance : AppRoutes.activity
+    const nextPage = router.query.next === AppRoutes.governance ? AppRoutes.governance : AppRoutes.activity
     router.push(nextPage)
   }
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -18,7 +18,7 @@ export const TREZOR_EMAIL = 'support@safe.global'
 // Deployments
 export const DEPLOYMENT_URL = IS_PRODUCTION
   ? 'https://community.safe.global'
-  : 'https://token_locking--governance.review-react-br.5afe.dev'
+  : 'https://safe-dao-governance.dev.5afe.dev'
 
 export const GATEWAY_URL = IS_PRODUCTION ? 'https://safe-client.safe.global' : 'https://safe-client.staging.5afe.dev'
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -17,8 +17,8 @@ export const TREZOR_EMAIL = 'support@safe.global'
 
 // Deployments
 export const DEPLOYMENT_URL = IS_PRODUCTION
-  ? 'https://governance.safe.global'
-  : 'https://safe-dao-governance.dev.5afe.dev/'
+  ? 'https://community.safe.global'
+  : 'https://token_locking--governance.review-react-br.5afe.dev'
 
 export const GATEWAY_URL = IS_PRODUCTION ? 'https://safe-client.safe.global' : 'https://safe-client.staging.5afe.dev'
 

--- a/src/utils/safe-apps.ts
+++ b/src/utils/safe-apps.ts
@@ -5,7 +5,7 @@ export const getGovernanceAppSafeAppUrl = (chainId: string, address: string): st
 
   const shortName = CHAIN_SHORT_NAME[chainId]
   url.searchParams.append('safe', `${shortName}:${address}`)
-  url.searchParams.append('appUrl', DEPLOYMENT_URL)
+  url.searchParams.append('appUrl', `${DEPLOYMENT_URL}/governance`)
 
   return url.toString()
 }


### PR DESCRIPTION
## What this PR changes
- Add optional `query` object to `Redirect` component props
- If set it sets the query parameters when redirecting
- Set initially opened page as query param when redirecting to splash screen
- If the query param requests the governance app we forward there instead of to the activity app