### PR TITLE
Fix: non number inputs

### DIFF
--- a/src/utils/__tests__/boost.test.ts
+++ b/src/utils/__tests__/boost.test.ts
@@ -23,6 +23,11 @@ describe('boost', () => {
   })
 
   describe('getTokenBoost', () => {
+    it('should return 0 for NaN amount', () => {
+      expect(getTokenBoost(Number('*'))).toBe(0)
+      expect(getTokenBoost(Number('100-10'))).toBe(0)
+      expect(getTokenBoost(Number('100**10'))).toBe(0)
+    })
     it('should return 0 for amounts below 100', () => {
       expect(getTokenBoost(0)).toBe(0)
       expect(getTokenBoost(1)).toBe(0)
@@ -78,6 +83,14 @@ describe('boost', () => {
 
   describe('getBoostFunction', () => {
     describe('without prior locks on day 0', () => {
+      it('should always return 1.0 for amount NaN', () => {
+        const boostFunction = getBoostFunction(0, Number.NaN, [])
+        expect(boostFunction({ x: -1 })).toBe(1)
+        expect(boostFunction({ x: 0 })).toBe(1)
+        expect(boostFunction({ x: SEASON1_START })).toBe(1)
+        expect(boostFunction({ x: SEASON2_START })).toBe(1)
+        expect(boostFunction({ x: 1000 })).toBe(1)
+      })
       it('should always return 1.0 for amount 0', () => {
         const boostFunction = getBoostFunction(0, 0, [])
         expect(boostFunction({ x: -1 })).toBe(1)
@@ -132,6 +145,19 @@ describe('boost', () => {
       // 1.0 * 0.86 + 1 = 1.86
       expect(boostFunction({ x: 45 })).toBeCloseTo(1.86)
       expect(boostFunction({ x: 1000 })).toBeCloseTo(1.86)
+    })
+
+    it('should keep boost unchanged if NaN is the locked amount', () => {
+      const priorLock: LockHistory = {
+        day: 0,
+        amount: 1000,
+      }
+      const boostFunction = getBoostFunction(40, Number.NaN, [priorLock])
+
+      expect(boostFunction({ x: -1 })).toBe(1)
+      expect(boostFunction({ x: 0 })).toBeCloseTo(1.25)
+      expect(boostFunction({ x: 40 })).toBeCloseTo(1.25)
+      expect(boostFunction({ x: 1000 })).toBeCloseTo(1.25)
     })
 
     it('should compute for 1000 tokens on day one and 1000 after 40 days', () => {

--- a/src/utils/boost.ts
+++ b/src/utils/boost.ts
@@ -6,7 +6,7 @@ export const floorNumber = (num: number, digits: number) => {
 }
 
 export const getTokenBoost = (amountLocked: number) => {
-  if (amountLocked <= 100) {
+  if (isNaN(amountLocked) || amountLocked <= 100) {
     return 0
   }
   if (amountLocked <= 1_000) {
@@ -44,7 +44,7 @@ export const getBoostFunction =
   (now: number, amountDiff: number, history: LockHistory[]) =>
   (d: { x: number }): number => {
     // Add new boost to history
-    const newHistory: LockHistory[] = [...history, { amount: amountDiff, day: now }]
+    const newHistory: LockHistory[] = [...history, { amount: isNaN(amountDiff) ? 0 : amountDiff, day: now }]
 
     // Filter out all entries that were made after the current day (x)
     const filteredHistory = newHistory.filter((entry) => entry.day <= d.x)


### PR DESCRIPTION
## Resolves
https://www.notion.so/safe-global/5300d6ffcb2043cc9e7fcd10bf14dff5?v=97acdfbecf184482a82449013cc519e9&p=ff6f078ceeb149508a95289f2dd1ba6b&pm=s

## What this PR changes
- Handles NaN correctly in TokenBoost function and boost function