### PR TITLE
Fix: small graph adjustments

### DIFF
--- a/src/components/TokenLocking/BoostBreakdown.tsx
+++ b/src/components/TokenLocking/BoostBreakdown.tsx
@@ -54,17 +54,20 @@ export const BoostBreakdown = ({
   return (
     <Stack direction={{ md: 'column' }} gap={2} height="100%">
       <Box className={`${css.boostInfoBox} ${css.bordered}`} p={4} gap={4} flex="2" height="100%" display="flex">
-        <span style={{ display: 'inline-flex' }}>
-          {!isInitialState && (
-            <>
-              <SignalCellularAlt color="border" fontSize="large" />
-              <BoostStrengthSignal
-                boost={newFinalBoost}
-                color={isVisibleDifference ? (isLock ? 'primary' : 'warning') : undefined}
-              />
-            </>
-          )}
-        </span>
+        <Box display="flex" flexDirection="row" justifyContent="space-between" alignItems="center">
+          <span style={{ display: 'inline-flex' }}>
+            {!isInitialState && (
+              <>
+                <SignalCellularAlt color="border" fontSize="large" />
+                <BoostStrengthSignal
+                  boost={newFinalBoost}
+                  color={isVisibleDifference ? (isLock ? 'primary' : 'warning') : undefined}
+                />
+              </>
+            )}
+          </span>
+          <Typography color="text.secondary">Current boost: {floorNumber(currentFinalBoost, 2)}x</Typography>
+        </Box>
 
         {isInitialState ? (
           <Stack mt={4} spacing={4}>

--- a/src/components/TokenLocking/BoostGraph/AxisTopLabel.tsx
+++ b/src/components/TokenLocking/BoostGraph/AxisTopLabel.tsx
@@ -1,5 +1,5 @@
 import { formatDay } from '@/utils/date'
-import { VictoryLabel, VictoryLabelProps, VictoryLabelStyleObject } from 'victory'
+import { VictoryLabel, VictoryLabelProps } from 'victory'
 
 export const AxisTopLabel = ({ startTime, ...props }: VictoryLabelProps & { startTime: number; datum?: number }) => {
   const days = props.datum
@@ -10,10 +10,12 @@ export const AxisTopLabel = ({ startTime, ...props }: VictoryLabelProps & { star
 
   const dateLabel = formatDay(days, startTime)
 
+  const style = props.style && !Array.isArray(props.style) ? props.style : {}
+
   return (
     <>
-      <VictoryLabel {...props} dy={0} style={{ fontSize: '11px' }} />
-      <VictoryLabel {...props} dy={16} text={dateLabel} style={{ fontSize: '11px', fill: '#FFF' }} />
+      <VictoryLabel {...props} dy={0} style={{ ...style, fontSize: '11px' }} />
+      <VictoryLabel {...props} dy={16} text={dateLabel} style={{ ...style, fontSize: '11px', fill: '#FFF' }} />
     </>
   )
 }

--- a/src/components/TokenLocking/BoostGraph/AxisTopLabel.tsx
+++ b/src/components/TokenLocking/BoostGraph/AxisTopLabel.tsx
@@ -1,5 +1,5 @@
 import { formatDay } from '@/utils/date'
-import { VictoryLabel, VictoryLabelProps } from 'victory'
+import { VictoryLabel, VictoryLabelProps, VictoryLabelStyleObject } from 'victory'
 
 export const AxisTopLabel = ({ startTime, ...props }: VictoryLabelProps & { startTime: number; datum?: number }) => {
   const days = props.datum
@@ -12,8 +12,8 @@ export const AxisTopLabel = ({ startTime, ...props }: VictoryLabelProps & { star
 
   return (
     <>
-      <VictoryLabel {...props} dy={-8} style={{ ...props.style, fontSize: '11px' }} />
-      <VictoryLabel {...props} dy={16} text={dateLabel} />
+      <VictoryLabel {...props} dy={0} style={{ fontSize: '11px' }} />
+      <VictoryLabel {...props} dy={16} text={dateLabel} style={{ fontSize: '11px', fill: '#FFF' }} />
     </>
   )
 }

--- a/src/components/TokenLocking/BoostGraph/BoostGraph.tsx
+++ b/src/components/TokenLocking/BoostGraph/BoostGraph.tsx
@@ -189,7 +189,7 @@ export const BoostGraph = ({
             />
           }
           domain={DOMAIN}
-          data={projectedBoostDataPoints}
+          data={pastLockPoints}
           theme={victoryTheme}
         />
         <VictoryScatter
@@ -206,7 +206,7 @@ export const BoostGraph = ({
               fill: theme.palette.text.primary,
             },
           }}
-          labels={[format(newBoostFunction({ x: SEASON2_START })) + 'x']}
+          labels={[format(newBoostFunction({ x: now })) + 'x', format(newBoostFunction({ x: SEASON2_START })) + 'x']}
           labelComponent={
             <ArrowDownLabel backgroundColor={isLock ? theme.palette.primary.main : theme.palette.warning.main} />
           }
@@ -218,7 +218,10 @@ export const BoostGraph = ({
             />
           }
           domain={DOMAIN}
-          data={[{ x: SEASON2_START, y: newBoostFunction({ x: SEASON2_START }) }]}
+          data={[
+            { x: now, y: newBoostFunction({ x: now }) },
+            { x: SEASON2_START, y: newBoostFunction({ x: SEASON2_START }) },
+          ]}
           theme={victoryTheme}
         />
       </VictoryChart>

--- a/src/components/TokenLocking/BoostGraph/BoostGraph.tsx
+++ b/src/components/TokenLocking/BoostGraph/BoostGraph.tsx
@@ -189,7 +189,7 @@ export const BoostGraph = ({
             />
           }
           domain={DOMAIN}
-          data={pastLockPoints}
+          data={projectedBoostDataPoints}
           theme={victoryTheme}
         />
         <VictoryScatter
@@ -206,10 +206,7 @@ export const BoostGraph = ({
               fill: theme.palette.text.primary,
             },
           }}
-          labels={[
-            format(currentBoostFunction({ x: now })) + 'x',
-            format(newBoostFunction({ x: SEASON2_START })) + 'x',
-          ]}
+          labels={[format(newBoostFunction({ x: SEASON2_START })) + 'x']}
           labelComponent={
             <ArrowDownLabel backgroundColor={isLock ? theme.palette.primary.main : theme.palette.warning.main} />
           }
@@ -221,10 +218,7 @@ export const BoostGraph = ({
             />
           }
           domain={DOMAIN}
-          data={[
-            { x: now, y: currentBoostFunction({ x: now }) },
-            { x: SEASON2_START, y: newBoostFunction({ x: SEASON2_START }) },
-          ]}
+          data={[{ x: SEASON2_START, y: newBoostFunction({ x: SEASON2_START }) }]}
           theme={victoryTheme}
         />
       </VictoryChart>

--- a/src/components/TokenLocking/BoostGraph/ScatterDot.tsx
+++ b/src/components/TokenLocking/BoostGraph/ScatterDot.tsx
@@ -35,6 +35,21 @@ export const ScatterDot = ({
           onMouseEnter={() => setHovered(true)}
           onMouseLeave={() => setHovered(false)}
         />
+        {hovered && props.datum.x !== SEASON2_START && (
+          <ArrowDownLabel
+            style={{
+              verticalAnchor: 'middle',
+              textAnchor: 'middle',
+              fontFamily: 'DM Sans',
+              fontSize: 14,
+              fill: theme.palette.text.primary,
+            }}
+            x={props.x}
+            y={props.y}
+            text={`${floorNumber(props.datum.y, 2)}x`}
+            backgroundColor={backgroundColor}
+          />
+        )}
       </>
     )
   }
@@ -60,7 +75,7 @@ export const ScatterDot = ({
             verticalAnchor: 'middle',
             textAnchor: 'middle',
             fontFamily: 'DM Sans',
-            fontSize: 16,
+            fontSize: 14,
             fill: theme.palette.text.primary,
           }}
           x={props.x}

--- a/src/components/TokenLocking/BoostGraph/helper.ts
+++ b/src/components/TokenLocking/BoostGraph/helper.ts
@@ -6,8 +6,10 @@ export const generatePointsFromHistory = (pastLocks: LockHistory[], nowInDays: n
   // find each individual day
   const days = pastLocks.map((lock) => lock.day).filter((day, index, days) => days.indexOf(day) === index)
 
-  return days.map((day) => ({
-    x: day,
-    y: boostFunction({ x: day }),
-  }))
+  return days
+    .map((day) => ({
+      x: day,
+      y: boostFunction({ x: day }),
+    }))
+    .slice(0, -1)
 }


### PR DESCRIPTION
## What this PR changes
- Adjusts labels slightly
- Removes always visible tooltip for today
- uses projected boost for today's marker
- Moves current boost to the boost breakdown

## Screenshot
![Screenshot 2024-04-18 at 12 06 26](https://github.com/safe-global/safe-dao-governance-app/assets/2670790/3bef6909-e0f4-4b74-904d-e148d9506dcc)
