### PR TITLE
Fix: empty leaderboard

### DIFF
--- a/src/components/TokenLocking/Leaderboard.tsx
+++ b/src/components/TokenLocking/Leaderboard.tsx
@@ -158,6 +158,7 @@ const LeaderboardPage = ({
 }): ReactElement => {
   const leaderboardPage = useGlobalLeaderboardPage(PAGE_SIZE, index * PAGE_SIZE)
   const rows = leaderboardPage?.results ?? []
+  const isLeaderboardEmpty = index === 0 && (!rows || rows.length === 0)
 
   if (leaderboardPage === undefined) {
     return (
@@ -172,6 +173,18 @@ const LeaderboardPage = ({
           <StyledTableCell align="left">
             <Skeleton />
           </StyledTableCell>
+        </StyledTableRow>
+      </>
+    )
+  }
+  if (isLeaderboardEmpty) {
+    return (
+      <>
+        <StyledTableRow>
+          <StyledTableCell colSpan={2}>
+            <Typography>No entries</Typography>
+          </StyledTableCell>
+          <StyledTableCell></StyledTableCell>
         </StyledTableRow>
       </>
     )


### PR DESCRIPTION
## What this PR changes
- Adds placeholder text for empty leaderboard

## Screenshot
<img width="952" alt="Screenshot 2024-04-18 at 16 41 00" src="https://github.com/safe-global/safe-dao-governance-app/assets/2670790/dab01b4f-7566-4196-bc09-e14c06732bad">
