### PR TITLE
fix: lock token button alignment

### DIFF
--- a/src/components/TockenUnlocking/UnlockTokenWidget.tsx
+++ b/src/components/TockenUnlocking/UnlockTokenWidget.tsx
@@ -163,7 +163,6 @@ export const UnlockTokenWidget = ({
                       </InputAdornment>
                     ),
                   }}
-                  className={css.input}
                 />
               </Grid>
 

--- a/src/components/TokenLocking/LockTokenWidget.tsx
+++ b/src/components/TokenLocking/LockTokenWidget.tsx
@@ -1,4 +1,3 @@
-import { formatAmount } from '@/utils/formatters'
 import { Typography, Stack, Grid, TextField, InputAdornment, Button, Box, CircularProgress } from '@mui/material'
 import NorthEastIcon from '@mui/icons-material/NorthEast'
 import { formatUnits, parseUnits } from 'ethers/lib/utils'
@@ -27,6 +26,7 @@ import { useSafeTokenLockingAllowance } from '@/hooks/useSafeTokenBalance'
 import { useStartDate } from '@/hooks/useStartDates'
 import { NAVIGATION_EVENTS } from '@/analytics/navigation'
 import { ExternalLink } from '../ExternalLink'
+import { formatAmount } from '@/utils/formatters'
 
 export const LockTokenWidget = ({ safeBalance }: { safeBalance: BigNumberish | undefined }) => {
   const [receiptOpen, setReceiptOpen] = useState<boolean>(false)
@@ -177,17 +177,17 @@ export const LockTokenWidget = ({ safeBalance }: { safeBalance: BigNumberish | u
 
             <Grid container spacing={2} mb={1} alignItems="center">
               <Grid item xs={12} md={8}>
-                <Typography mb={1}>Select amount to lock</Typography>
+                <Typography>Select amount to unlock</Typography>
                 <TextField
                   variant="outlined"
                   fullWidth
+                  value={amount}
+                  helperText={amountError ?? ' '}
+                  error={Boolean(amountError)}
+                  onChange={onChangeAmount}
                   onFocus={(event) => {
                     event.target.select()
                   }}
-                  value={amount}
-                  onChange={onChangeAmount}
-                  helperText={amountError}
-                  error={!!amountError}
                   InputProps={{
                     startAdornment: (
                       <InputAdornment position="start" sx={{ width: '24px', height: '24px' }}>
@@ -204,9 +204,6 @@ export const LockTokenWidget = ({ safeBalance }: { safeBalance: BigNumberish | u
                   }}
                   className={css.input}
                 />
-                <Typography variant="caption">
-                  Balance: {formatAmount(formatUnits(safeBalance ?? '0', 18), 2)}
-                </Typography>
               </Grid>
 
               <Grid item xs={12} md={4}>
@@ -217,6 +214,7 @@ export const LockTokenWidget = ({ safeBalance }: { safeBalance: BigNumberish | u
                 </Track>
               </Grid>
             </Grid>
+            <Typography variant="caption">Balance: {formatAmount(formatUnits(safeBalance ?? '0', 18), 2)}</Typography>
           </Grid>
           <Grid item xs={12} md={4}>
             <BoostBreakdown

--- a/src/components/TokenLocking/LockTokenWidget.tsx
+++ b/src/components/TokenLocking/LockTokenWidget.tsx
@@ -177,7 +177,7 @@ export const LockTokenWidget = ({ safeBalance }: { safeBalance: BigNumberish | u
 
             <Grid container spacing={2} mb={1} alignItems="center">
               <Grid item xs={12} md={8}>
-                <Typography>Select amount to unlock</Typography>
+                <Typography>Select amount to lock</Typography>
                 <TextField
                   variant="outlined"
                   fullWidth


### PR DESCRIPTION
## What it solves
Lock button is too high in relation to the token input. It is too low when there is an input error.
<img width="565" alt="image" src="https://github.com/safe-global/safe-dao-governance-app/assets/17801424/cc4ef963-99c4-45ff-a72b-3d87e246e087">

## How this PR fixes it
Center button with the input in both error and non error states
