### PR TITLE
Fix: Make follow on X link easier to click

### DIFF
--- a/src/components/Activities/index.tsx
+++ b/src/components/Activities/index.tsx
@@ -93,9 +93,9 @@ const Activities = () => {
                 title="Other activities coming soon"
                 description={
                   <>
-                    To stay updated follow us on{' '}
+                    To stay updated{' '}
                     <ExternalLink icon={false} href="https://twitter.com/safe">
-                      X
+                      follow us on X
                     </ExternalLink>{' '}
                     and{' '}
                     <ExternalLink icon={false} href="https://warpcast.com/safe">


### PR DESCRIPTION
Make the link  `Follow us on X` instead of just `X`

<img width="322" alt="image" src="https://github.com/safe-global/safe-dao-governance-app/assets/17801424/187a7264-5e17-43cc-87e6-4ba23e352971">
