### PR TITLE
Fix: Stop page from jumping from input error message on claim page

### DIFF
--- a/src/components/Claim/index.tsx
+++ b/src/components/Claim/index.tsx
@@ -226,7 +226,7 @@ const ClaimOverview = (): ReactElement => {
                   fullWidth
                   value={amount}
                   error={!!amountError}
-                  helperText={amountError}
+                  helperText={amountError ?? ' '}
                   onChange={onChangeAmount}
                   InputProps={{
                     startAdornment: (


### PR DESCRIPTION
Reserve space for the error message so the page below doesn't jump down when the error appears