### PR TITLE
fix: app icon url for wallet connect

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "safe-dao-governance-app",
   "homepage": "https://github.com/safe-global/safe-dao-governance-app",
   "license": "GPL-3.0",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "scripts": {
     "build": "next build && next export",
     "lint": "tsc && next lint",

--- a/src/utils/onboard.ts
+++ b/src/utils/onboard.ts
@@ -58,7 +58,7 @@ export const createOnboard = (chainConfigs: ChainInfo[], currentChain: ChainInfo
     },
     appMetadata: {
       name: manifestJson.name,
-      icon: '/images/app-logo.svg',
+      icon: location.origin + '/images/app-logo.svg',
       description: `Please select a wallet to connect to ${manifestJson.name}`,
     },
     connect: {


### PR DESCRIPTION
## What this PR fixes
- When wallet connect establishes a connection it could not find the app's icon and showed a placeholder

## Screenshot
<img width="527" alt="Screenshot 2024-04-22 at 13 53 27" src="https://github.com/safe-global/safe-dao-governance-app/assets/2670790/acd6152b-bb09-4290-865f-fc3c4ab948f4">
