### PR TITLE
fix: add padding for legal disclaimer on mobile

### DIFF
--- a/src/components/TokenLocking/index.tsx
+++ b/src/components/TokenLocking/index.tsx
@@ -50,7 +50,7 @@ const TokenLocking = () => {
           <PaperContainer>
             <Leaderboard />
           </PaperContainer>
-          <Box>
+          <Box px={{ xs: 4, md: 0 }}>
             <Typography variant="overline" fontWeight="bold" color="text.secondary">
               LEGAL DISCLAIMER
             </Typography>
@@ -71,7 +71,7 @@ const TokenLocking = () => {
               DOES NOT GRANT YOU ANY CONTRACTUAL CLAIM TO RECEIVE REWARDS.
             </Typography>
           </Box>
-          <ExternalLink href={SAFE_TERMS_AND_CONDITIONS_URL} m={2}>
+          <ExternalLink href={SAFE_TERMS_AND_CONDITIONS_URL} m={2} px={{ xs: 4, md: 0 }}>
             Terms and Conditions
           </ExternalLink>
         </Stack>

--- a/src/components/TokenLocking/index.tsx
+++ b/src/components/TokenLocking/index.tsx
@@ -71,7 +71,7 @@ const TokenLocking = () => {
               DOES NOT GRANT YOU ANY CONTRACTUAL CLAIM TO RECEIVE REWARDS.
             </Typography>
           </Box>
-          <ExternalLink href={SAFE_TERMS_AND_CONDITIONS_URL} m={2} px={{ xs: 4, md: 0 }}>
+          <ExternalLink href={SAFE_TERMS_AND_CONDITIONS_URL} px={{ xs: 4, md: 0 }}>
             Terms and Conditions
           </ExternalLink>
         </Stack>


### PR DESCRIPTION


<img width="367" alt="image" src="https://github.com/safe-global/safe-dao-governance-app/assets/17801424/5d4bf0fa-e2d7-4197-9c08-46b36017295b">
