### PR TITLE
fix: add gap to current boost

### DIFF
--- a/src/components/TokenLocking/BoostBreakdown.tsx
+++ b/src/components/TokenLocking/BoostBreakdown.tsx
@@ -54,7 +54,7 @@ export const BoostBreakdown = ({
   return (
     <Stack direction={{ md: 'column' }} gap={2} height="100%">
       <Box className={`${css.boostInfoBox} ${css.bordered}`} p={4} gap={4} flex="2" height="100%" display="flex">
-        <Box display="flex" flexDirection="row" justifyContent="space-between" alignItems="center">
+        <Box display="flex" flexDirection="row" justifyContent="space-between" alignItems="center" gap={2}>
           <span style={{ display: 'inline-flex' }}>
             {!isInitialState && (
               <>


### PR DESCRIPTION
## What this PR changes
- adds 16px gap to boost breakdown current boost

## Screenshots
Before:
![Screenshot 2024-04-23 at 08 51 41](https://github.com/safe-global/safe-dao-governance-app/assets/2670790/a9b1240c-3bc4-40c1-a803-48415b9d0e08)

After:
![Screenshot 2024-04-23 at 08 51 36](https://github.com/safe-global/safe-dao-governance-app/assets/2670790/af1c4993-cd19-48ba-b811-d6eb0de65a90)
