### PR TITLE
fix: hide navigation on splash screen, do not disconnect safe-apps

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -17,7 +17,6 @@ import { useInitWeb3 } from '@/hooks/useWeb3'
 import initTheme from '@/styles/theme'
 import { useDelegatesFile } from '@/hooks/useDelegatesFile'
 import { useChain } from '@/hooks/useChain'
-import { PageLayout } from '@/components/PageLayout'
 import { useIsTokenPaused } from '@/hooks/useIsTokenPaused'
 import { useInitWallet } from '@/hooks/useWallet'
 import { EnsureWalletConnection } from '@/components/EnsureWalletConnection'
@@ -90,13 +89,7 @@ const App = ({
         <SafeProvider>
           <InitApp />
 
-          {isDashboard(pathname) ? (
-            page
-          ) : (
-            <PageLayout>
-              <EnsureWalletConnection>{page}</EnsureWalletConnection>
-            </PageLayout>
-          )}
+          {isDashboard(pathname) ? page : <EnsureWalletConnection>{page}</EnsureWalletConnection>}
         </SafeProvider>
       </CssVarsProvider>
     </CacheProvider>

--- a/src/components/EnsureWalletConnection/index.tsx
+++ b/src/components/EnsureWalletConnection/index.tsx
@@ -4,6 +4,8 @@ import type { ReactElement } from 'react'
 import { AppRoutes } from '@/config/routes'
 import { useWeb3 } from '@/hooks/useWeb3'
 import { SplashScreen } from '../SplashScreen'
+import { useIsSafeApp } from '@/hooks/useIsSafeApp'
+import { PageLayout } from '../PageLayout'
 
 const isProviderRoute = (pathname: string) => {
   return [
@@ -19,8 +21,15 @@ const isProviderRoute = (pathname: string) => {
 export const EnsureWalletConnection = ({ children }: { children: ReactElement }): ReactElement => {
   const router = useRouter()
   const web3 = useWeb3()
+  const isSafeApp = useIsSafeApp()
 
-  const shouldRedirect = !web3 && isProviderRoute(router.pathname)
+  const shouldRedirect = !web3 && isProviderRoute(router.pathname) && !isSafeApp
 
-  return shouldRedirect ? <SplashScreen /> : children
+  return shouldRedirect ? (
+    <PageLayout hideNavigation>
+      <SplashScreen />
+    </PageLayout>
+  ) : (
+    <PageLayout>{children}</PageLayout>
+  )
 }

--- a/src/components/PageLayout/index.tsx
+++ b/src/components/PageLayout/index.tsx
@@ -14,9 +14,15 @@ import { NAVIGATION_EVENTS } from '@/analytics/navigation'
 
 const RoutesWithNavigation = [AppRoutes.index, AppRoutes.activity, AppRoutes.governance]
 
-export const PageLayout = ({ children }: { children: ReactNode }): ReactElement => {
+export const PageLayout = ({
+  children,
+  hideNavigation,
+}: {
+  children: ReactNode
+  hideNavigation?: boolean
+}): ReactElement => {
   const router = useRouter()
-  const showNavigation = RoutesWithNavigation.includes(router.route)
+  const showNavigation = RoutesWithNavigation.includes(router.route) && !hideNavigation
 
   return (
     <>

--- a/src/hooks/useWeb3.ts
+++ b/src/hooks/useWeb3.ts
@@ -6,7 +6,6 @@ import { useWallet } from '@/hooks/useWallet'
 import { useIsSafeApp } from '@/hooks/useIsSafeApp'
 import { ExternalStore } from '@/services/ExternalStore'
 import { createSafeProvider, createWeb3Provider } from '@/utils/web3'
-import { isSafe } from '@/utils/wallet'
 
 const web3Store = new ExternalStore<JsonRpcProvider>()
 

--- a/src/hooks/useWeb3.ts
+++ b/src/hooks/useWeb3.ts
@@ -6,6 +6,7 @@ import { useWallet } from '@/hooks/useWallet'
 import { useIsSafeApp } from '@/hooks/useIsSafeApp'
 import { ExternalStore } from '@/services/ExternalStore'
 import { createSafeProvider, createWeb3Provider } from '@/utils/web3'
+import { isSafe } from '@/utils/wallet'
 
 const web3Store = new ExternalStore<JsonRpcProvider>()
 
@@ -27,6 +28,9 @@ export const useInitWeb3 = (): void => {
       return
     }
 
-    web3Store.setStore(undefined)
+    // A Safe app can not disconnect
+    if (!isSafeApp) {
+      web3Store.setStore(undefined)
+    }
   }, [isSafeApp, sdk, wallet?.provider])
 }


### PR DESCRIPTION
## What this PR fixes
- When in a Safe App we do not disconnect the wallet by setting web3 to undefined
- Hide navigation in Splash Screen
