### PR TITLE
Fix: show an alert if not a Safe

### DIFF
--- a/src/components/SplashScreen/index.tsx
+++ b/src/components/SplashScreen/index.tsx
@@ -60,6 +60,7 @@ export const SplashScreen = (): ReactElement => {
       if (wallet && !isSafeApp && !(await isSafe(wallet))) {
         await onboard.disconnectWallet({ label: wallet.label })
         setError('Connected wallet must be a Safe')
+        alert('Connected wallet is not a Safe Account. Please connect a Safe Account.')
         return
       }
     } catch (error) {


### PR DESCRIPTION
If the connected wallet is not a Safe, show a simple browser alert prompting to connect to a Safe Account.

<img width="1596" alt="Screenshot 2024-04-24 at 12 54 58" src="https://github.com/safe-global/safe-dao-governance-app/assets/381895/86286f5e-275a-4369-b812-c566730ee959">
