### PR TITLE
fix: do not decrease boost if locked amount remains above max amount

### DIFF
--- a/src/utils/__tests__/boost.test.ts
+++ b/src/utils/__tests__/boost.test.ts
@@ -216,6 +216,21 @@ describe('boost', () => {
       expect(boostFunction({ x: 1000 })).toBe(1)
     })
 
+    it('should not decrease the boost if locked amount is > 100k after unlocking', () => {
+      const priorLocks: LockHistory[] = [
+        {
+          day: 0,
+          amount: 200_000,
+        },
+      ]
+      const boostFunction = getBoostFunction(39, -100_000, priorLocks)
+
+      expect(boostFunction({ x: -1 })).toBe(1)
+      expect(boostFunction({ x: 0 })).toBeCloseTo(2)
+      expect(boostFunction({ x: 39 })).toBe(2)
+      expect(boostFunction({ x: 1000 })).toBe(2)
+    })
+
     it('should compute for 2000 tokens on day one, unlocking 1000 after 40 days and locking another 1000 after 80 days', () => {
       const priorLocks: LockHistory[] = [
         {

--- a/src/utils/boost.ts
+++ b/src/utils/boost.ts
@@ -1,5 +1,7 @@
 import { LockHistory } from './lock'
 
+const MAX_AMOUNT = 100_000
+
 export const floorNumber = (num: number, digits: number) => {
   const decimal = Math.pow(10, digits)
   return Math.floor(num * decimal) / decimal
@@ -59,7 +61,9 @@ export const getBoostFunction =
         currentBoost = currentBoost + boostGain * timeFactorLock
       } else {
         // handle unlock
-        currentBoost = getTokenBoost(lockedAmount) * getTimeFactor(currentEvent.day) + 1
+        if (lockedAmount < MAX_AMOUNT) {
+          currentBoost = getTokenBoost(lockedAmount) * getTimeFactor(currentEvent.day) + 1
+        }
       }
     }
 


### PR DESCRIPTION
## What is this PR about?
If users who locked more than the maximum (100k) unlock tokens such that the locked amount is still >= 100k SAFE, we do not decrease the boost.