### PR TITLE
fix: do not fetch leaderboard if no wallet connected

### DIFF
--- a/src/hooks/useLeaderboard.ts
+++ b/src/hooks/useLeaderboard.ts
@@ -72,7 +72,7 @@ export const useOwnCampaignRank = (resourceId: string | undefined) => {
   const gatewayBaseUrl = useGatewayBaseUrl()
 
   const getKey = (resourceId: string | undefined) => {
-    if (!resourceId) {
+    if (!resourceId || !address) {
       return null
     }
     // Load next page


### PR DESCRIPTION
## What this PR changes
If no wallet is connected we no longer try to fetch the own rank for the campaign leaderboard.