### PR TITLE
feat: show weekly update separately, redesign some components

### DIFF
--- a/src/components/Points/ActivityPointsFeed.tsx
+++ b/src/components/Points/ActivityPointsFeed.tsx
@@ -66,7 +66,7 @@ export const ActivityPointsFeed = ({ campaign }: { campaign?: Campaign }) => {
   const [showOverallPoints, setShowOverallPoints] = useState(false)
 
   useEffect(() => {
-    if (ownEntry === undefined || isLoading || isLatestUpdateLoading) {
+    if (isLoading || isLatestUpdateLoading) {
       return
     }
     const showBoostPointsTimeout = setTimeout(() => setShowBoostPoints(true), 1000)

--- a/src/components/Points/ActivityPointsFeed.tsx
+++ b/src/components/Points/ActivityPointsFeed.tsx
@@ -35,6 +35,19 @@ const HiddenValue = () => (
   </Typography>
 )
 
+const DataWrapper = ({ children }: { children: ReactNode }) => {
+  return (
+    <Stack
+      direction={{ xs: 'column', lg: 'row' }}
+      justifyContent="space-between"
+      alignItems={{ xs: 'start', lg: 'center' }}
+      spacing={2}
+    >
+      {children}
+    </Stack>
+  )
+}
+
 export const ActivityPointsFeed = ({ campaign }: { campaign?: Campaign }) => {
   const { data: ownEntry, isLoading } = useOwnCampaignRank(campaign?.resourceId)
   const { data: latestUpdate, isLoading: isLatestUpdateLoading } = useLatestCampaignUpdate(campaign?.resourceId)
@@ -80,34 +93,34 @@ export const ActivityPointsFeed = ({ campaign }: { campaign?: Campaign }) => {
     return (
       <>
         <BorderedBox key={campaign?.resourceId}>
-          <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
+          <DataWrapper>
             <Typography color="text.secondary">Last drop</Typography>
             <HiddenValue />
-          </Stack>
+          </DataWrapper>
           <Divider
             sx={{
               marginRight: '-32px',
               marginLeft: '-32px',
             }}
           />
-          <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
+          <DataWrapper>
             <Typography color="text.secondary">Activity points</Typography>
             <HiddenValue />
-          </Stack>
-          <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
+          </DataWrapper>
+          <DataWrapper>
             <Typography color="text.secondary">Boost points</Typography>
             <HiddenValue />
-          </Stack>
+          </DataWrapper>
           <Divider />
-          <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
+          <DataWrapper>
             <Typography color="text.secondary">{!isGlobal && 'Campaign'} Week total</Typography>
             <HiddenValue />
-          </Stack>
+          </DataWrapper>
           <Divider />
-          <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
+          <DataWrapper>
             <Typography color="text.secondary">{!isGlobal && 'Campaign'} Overall</Typography>
             <HiddenValue />
-          </Stack>
+          </DataWrapper>
           <Typography mt={6} alignSelf="center" color="text.secondary">
             Your points are updated weekly.
           </Typography>
@@ -115,10 +128,10 @@ export const ActivityPointsFeed = ({ campaign }: { campaign?: Campaign }) => {
         </BorderedBox>
         {!isGlobal && (
           <BorderedBox>
-            <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
+            <DataWrapper>
               <Typography color="text.secondary">Campaign total</Typography>
               <HiddenValue />
-            </Stack>
+            </DataWrapper>
           </BorderedBox>
         )}
       </>
@@ -128,23 +141,27 @@ export const ActivityPointsFeed = ({ campaign }: { campaign?: Campaign }) => {
   return (
     <>
       <BorderedBox key={campaign?.resourceId}>
-        <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
+        <DataWrapper>
           <Typography color="text.secondary">Last drop</Typography>
-          <Typography color="text.secondary">{formatDate(new Date(campaign.lastUpdated))}</Typography>
-        </Stack>
+          {latestUpdate && (
+            <Typography color="text.secondary">
+              {formatDate(new Date(latestUpdate.startDate))} - {formatDate(new Date(latestUpdate.endDate))}
+            </Typography>
+          )}
+        </DataWrapper>
         <Divider
           sx={{
             marginRight: '-32px',
             marginLeft: '-32px',
           }}
         />
-        <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
+        <DataWrapper>
           <Typography color="text.secondary">Activity points</Typography>
           <PointsCounter value={Number(data.activityPoints)} fontWeight={700}>
             points
           </PointsCounter>
-        </Stack>
-        <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
+        </DataWrapper>
+        <DataWrapper>
           <Typography color="text.secondary">Boost points</Typography>
           {showBoostPoints ? (
             <PointsCounter value={Number(data.boostedPoints)} fontWeight={700}>
@@ -153,9 +170,9 @@ export const ActivityPointsFeed = ({ campaign }: { campaign?: Campaign }) => {
           ) : (
             <HiddenValue />
           )}
-        </Stack>
+        </DataWrapper>
         <Divider />
-        <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
+        <DataWrapper>
           <Typography>{!isGlobal && 'Campaign'} Week total</Typography>
           {showTotalPoints ? (
             <PointsCounter value={Number(data.totalPoints)} fontWeight={700}>
@@ -164,7 +181,7 @@ export const ActivityPointsFeed = ({ campaign }: { campaign?: Campaign }) => {
           ) : (
             <HiddenValue />
           )}
-        </Stack>
+        </DataWrapper>
         <Typography mt={6} alignSelf="center" color="text.secondary">
           Your points are updated weekly.
         </Typography>
@@ -173,7 +190,7 @@ export const ActivityPointsFeed = ({ campaign }: { campaign?: Campaign }) => {
 
       {!isGlobal && (
         <BorderedBox>
-          <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
+          <DataWrapper>
             <Typography color="text.secondary">Campaign total</Typography>
             {showOverallPoints ? (
               <PointsCounter value={Number(data.overallPoints)} fontWeight={700}>
@@ -182,7 +199,7 @@ export const ActivityPointsFeed = ({ campaign }: { campaign?: Campaign }) => {
             ) : (
               <HiddenValue />
             )}
-          </Stack>
+          </DataWrapper>
         </BorderedBox>
       )}
     </>

--- a/src/components/Points/ActivityPointsFeed.tsx
+++ b/src/components/Points/ActivityPointsFeed.tsx
@@ -2,13 +2,33 @@ import { GLOBAL_CAMPAIGN_IDS } from '@/config/constants'
 import { Campaign } from '@/hooks/useCampaigns'
 import { useChainId } from '@/hooks/useChainId'
 import { useOwnCampaignRank } from '@/hooks/useLeaderboard'
-import { formatDatetime } from '@/utils/date'
+import { formatDate } from '@/utils/date'
 import { Divider, Skeleton, Stack, Typography } from '@mui/material'
 import Box from '@mui/material/Box'
-import { useEffect, useMemo, useState } from 'react'
+import { ReactNode, useEffect, useMemo, useState } from 'react'
 import PointsCounter from '../PointsCounter'
 import Barcode from '@/public/images/horizontal_barcode.svg'
 import css from './styles.module.css'
+import { useLatestCampaignUpdate } from '@/hooks/useLatestCampaignUpdate'
+
+const BorderedBox = ({ children }: { children: ReactNode }) => {
+  return (
+    <Box
+      sx={{
+        border: ({ palette }) => `1px solid ${palette.border.light}`,
+        borderRadius: '6px',
+        p: '24px 32px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 2,
+        position: 'relative',
+      }}
+    >
+      {children}
+    </Box>
+  )
+}
+
 const HiddenValue = () => (
   <Typography minWidth="80px">
     <Skeleton />
@@ -17,29 +37,34 @@ const HiddenValue = () => (
 
 export const ActivityPointsFeed = ({ campaign }: { campaign?: Campaign }) => {
   const { data: ownEntry, isLoading } = useOwnCampaignRank(campaign?.resourceId)
+  const { data: latestUpdate, isLoading: isLatestUpdateLoading } = useLatestCampaignUpdate(campaign?.resourceId)
 
   const data = useMemo(() => {
     return {
-      activityPoints: ownEntry?.totalPoints ?? 0,
-      boostedPoints: ownEntry ? ownEntry.totalBoostedPoints - ownEntry.totalPoints : 0,
-      totalPoints: ownEntry?.totalBoostedPoints ?? 0,
+      activityPoints: latestUpdate?.totalPoints ?? 0,
+      boostedPoints: latestUpdate ? latestUpdate.totalBoostedPoints - latestUpdate.totalPoints : 0,
+      totalPoints: latestUpdate?.totalBoostedPoints ?? 0,
+      overallPoints: ownEntry?.totalBoostedPoints ?? 0,
     }
-  }, [ownEntry])
+  }, [latestUpdate, ownEntry])
 
   const [showBoostPoints, setShowBoostPoints] = useState(false)
   const [showTotalPoints, setShowTotalPoints] = useState(false)
+  const [showOverallPoints, setShowOverallPoints] = useState(false)
 
   useEffect(() => {
-    if (ownEntry !== undefined || !isLoading) {
+    if (ownEntry !== undefined || !isLoading || !isLatestUpdateLoading) {
       const showBoostPointsTimeout = setTimeout(() => setShowBoostPoints(true), 1000)
       const showTotalPointsTimeout = setTimeout(() => setShowTotalPoints(true), 2000)
+      const showOverallPointsTimeout = setTimeout(() => setShowOverallPoints(true), 3000)
 
       return () => {
         clearTimeout(showBoostPointsTimeout)
         clearTimeout(showTotalPointsTimeout)
+        clearTimeout(showOverallPointsTimeout)
       }
     }
-  }, [ownEntry, isLoading])
+  }, [ownEntry, isLoading, isLatestUpdateLoading])
 
   const chainId = useChainId()
 
@@ -53,81 +78,113 @@ export const ActivityPointsFeed = ({ campaign }: { campaign?: Campaign }) => {
 
   if (isLoading) {
     return (
-      <Box
-        key={campaign?.resourceId}
-        sx={{
-          border: ({ palette }) => `1px solid ${palette.border.light}`,
-          borderRadius: '6px',
-          p: '24px 32px',
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 2,
-          position: 'relative',
-        }}
-      >
-        <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
-          <Typography color="text.secondary">Activity points</Typography>
-          <HiddenValue />
-        </Stack>
-        <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
-          <Typography color="text.secondary">Boost points</Typography>
-          <HiddenValue />
-        </Stack>
-        <Divider />
-        <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
-          <Typography color="text.secondary">{!isGlobal && 'Campaign'} Total</Typography>
-          <HiddenValue />
-        </Stack>
-        <HiddenValue />
-        <Barcode className={css.barcode} />
-      </Box>
+      <>
+        <BorderedBox key={campaign?.resourceId}>
+          <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
+            <Typography color="text.secondary">Last drop</Typography>
+            <HiddenValue />
+          </Stack>
+          <Divider
+            sx={{
+              marginRight: '-32px',
+              marginLeft: '-32px',
+            }}
+          />
+          <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
+            <Typography color="text.secondary">Activity points</Typography>
+            <HiddenValue />
+          </Stack>
+          <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
+            <Typography color="text.secondary">Boost points</Typography>
+            <HiddenValue />
+          </Stack>
+          <Divider />
+          <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
+            <Typography color="text.secondary">{!isGlobal && 'Campaign'} Week total</Typography>
+            <HiddenValue />
+          </Stack>
+          <Divider />
+          <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
+            <Typography color="text.secondary">{!isGlobal && 'Campaign'} Overall</Typography>
+            <HiddenValue />
+          </Stack>
+          <Typography mt={6} alignSelf="center" color="text.secondary">
+            Your points are updated weekly.
+          </Typography>
+          <Barcode className={css.barcode} />
+        </BorderedBox>
+        {!isGlobal && (
+          <BorderedBox>
+            <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
+              <Typography color="text.secondary">Campaign total</Typography>
+              <HiddenValue />
+            </Stack>
+          </BorderedBox>
+        )}
+      </>
     )
   }
 
   return (
-    <Box
-      key={campaign?.resourceId}
-      sx={{
-        border: ({ palette }) => `1px solid ${palette.border.light}`,
-        borderRadius: '6px',
-        p: '24px 32px',
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 2,
-        position: 'relative',
-      }}
-    >
-      <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
-        <Typography color="text.secondary">Activity points</Typography>
-        <PointsCounter value={Number(data.activityPoints)} fontWeight={700}>
-          points
-        </PointsCounter>
-      </Stack>
-      <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
-        <Typography color="text.secondary">Boost points</Typography>
-        {showBoostPoints ? (
-          <PointsCounter value={Number(data.boostedPoints)} fontWeight={700}>
+    <>
+      <BorderedBox key={campaign?.resourceId}>
+        <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
+          <Typography color="text.secondary">Last drop</Typography>
+          <Typography color="text.secondary">{formatDate(new Date(campaign.lastUpdated))}</Typography>
+        </Stack>
+        <Divider
+          sx={{
+            marginRight: '-32px',
+            marginLeft: '-32px',
+          }}
+        />
+        <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
+          <Typography color="text.secondary">Activity points</Typography>
+          <PointsCounter value={Number(data.activityPoints)} fontWeight={700}>
             points
           </PointsCounter>
-        ) : (
-          <HiddenValue />
-        )}
-      </Stack>
-      <Divider />
-      <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
-        <Typography color="text.secondary">{!isGlobal && 'Campaign'} Total</Typography>
-        {showTotalPoints ? (
-          <PointsCounter value={Number(data.totalPoints)} fontWeight={700} fontSize="27px" color="primary">
-            points
-          </PointsCounter>
-        ) : (
-          <HiddenValue />
-        )}
-      </Stack>
-      <Typography mt={6} alignSelf="center" color="text.secondary">
-        Last updated {formatDatetime(new Date(campaign.lastUpdated))}
-      </Typography>
-      <Barcode className={css.barcode} />
-    </Box>
+        </Stack>
+        <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
+          <Typography color="text.secondary">Boost points</Typography>
+          {showBoostPoints ? (
+            <PointsCounter value={Number(data.boostedPoints)} fontWeight={700}>
+              points
+            </PointsCounter>
+          ) : (
+            <HiddenValue />
+          )}
+        </Stack>
+        <Divider />
+        <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
+          <Typography>{!isGlobal && 'Campaign'} Week total</Typography>
+          {showTotalPoints ? (
+            <PointsCounter value={Number(data.totalPoints)} fontWeight={700}>
+              points
+            </PointsCounter>
+          ) : (
+            <HiddenValue />
+          )}
+        </Stack>
+        <Typography mt={6} alignSelf="center" color="text.secondary">
+          Your points are updated weekly.
+        </Typography>
+        <Barcode className={css.barcode} />
+      </BorderedBox>
+
+      {!isGlobal && (
+        <BorderedBox>
+          <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
+            <Typography color="text.secondary">Campaign total</Typography>
+            {showOverallPoints ? (
+              <PointsCounter value={Number(data.overallPoints)} fontWeight={700}>
+                points
+              </PointsCounter>
+            ) : (
+              <HiddenValue />
+            )}
+          </Stack>
+        </BorderedBox>
+      )}
+    </>
   )
 }

--- a/src/components/Points/ActivityPointsFeed.tsx
+++ b/src/components/Points/ActivityPointsFeed.tsx
@@ -66,16 +66,17 @@ export const ActivityPointsFeed = ({ campaign }: { campaign?: Campaign }) => {
   const [showOverallPoints, setShowOverallPoints] = useState(false)
 
   useEffect(() => {
-    if (ownEntry !== undefined || !isLoading || !isLatestUpdateLoading) {
-      const showBoostPointsTimeout = setTimeout(() => setShowBoostPoints(true), 1000)
-      const showTotalPointsTimeout = setTimeout(() => setShowTotalPoints(true), 2000)
-      const showOverallPointsTimeout = setTimeout(() => setShowOverallPoints(true), 3000)
+    if (ownEntry === undefined || isLoading || isLatestUpdateLoading) {
+      return
+    }
+    const showBoostPointsTimeout = setTimeout(() => setShowBoostPoints(true), 1000)
+    const showTotalPointsTimeout = setTimeout(() => setShowTotalPoints(true), 2000)
+    const showOverallPointsTimeout = setTimeout(() => setShowOverallPoints(true), 3000)
 
-      return () => {
-        clearTimeout(showBoostPointsTimeout)
-        clearTimeout(showTotalPointsTimeout)
-        clearTimeout(showOverallPointsTimeout)
-      }
+    return () => {
+      clearTimeout(showBoostPointsTimeout)
+      clearTimeout(showTotalPointsTimeout)
+      clearTimeout(showOverallPointsTimeout)
     }
   }, [ownEntry, isLoading, isLatestUpdateLoading])
 

--- a/src/components/Points/CampaignTabs.tsx
+++ b/src/components/Points/CampaignTabs.tsx
@@ -1,6 +1,6 @@
 import Tabs from '@mui/material/Tabs'
 import Tab from '@mui/material/Tab'
-import { Box, Chip, Typography, useMediaQuery } from '@mui/material'
+import { Box, Chip, Typography } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 import css from './styles.module.css'
 
@@ -45,11 +45,10 @@ const CAMPAIGN_TABS = [
 
 const CampaignTabs = ({ onChange, selectedTabIdx }: { onChange: (tab: number) => void; selectedTabIdx: number }) => {
   const theme = useTheme()
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down('lg'))
   return (
     <Box padding="8px 0px">
       <Tabs
-        orientation={isSmallScreen ? 'horizontal' : 'vertical'}
+        orientation="vertical"
         variant="scrollable"
         value={selectedTabIdx}
         aria-label="Vertical tabs example"

--- a/src/components/Points/CampaignTabs.tsx
+++ b/src/components/Points/CampaignTabs.tsx
@@ -1,8 +1,8 @@
-import * as React from 'react'
 import Tabs from '@mui/material/Tabs'
 import Tab from '@mui/material/Tab'
 import { Box, Chip, Typography, useMediaQuery } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
+import css from './styles.module.css'
 
 const CAMPAIGN_TABS = [
   {
@@ -36,7 +36,7 @@ const CAMPAIGN_TABS = [
             marginRight: 1,
           }}
         />
-        Campaigns <Chip variant="outlined" sx={{ borderRadius: '16px' }} label="soon" />
+        Campaigns <Chip variant="outlined" className={css.comingSoon} label="soon" />
       </Typography>
     ),
     disabled: true,

--- a/src/components/Points/CampaignTabs.tsx
+++ b/src/components/Points/CampaignTabs.tsx
@@ -6,13 +6,37 @@ import { useTheme } from '@mui/material/styles'
 
 const CAMPAIGN_TABS = [
   {
-    label: 'Global',
+    label: (
+      <Typography display="flex" flexDirection="row" gap={1} alignItems="center" fontWeight={700}>
+        <Box
+          sx={{
+            borderRadius: '100%',
+            backgroundColor: ({ palette }) => palette.primary.main,
+            minWidth: '6px',
+            minHeight: '6px',
+            flexShrink: 0,
+            marginRight: 1,
+          }}
+        />
+        Global
+      </Typography>
+    ),
     disabled: false,
   },
   {
     label: (
-      <Typography display="flex" flexDirection="row" gap={1} alignItems="center">
-        Campaigns <Chip variant="outlined" sx={{ borderRadius: '4px' }} label="soon" />
+      <Typography display="flex" flexDirection="row" gap={1} alignItems="center" fontWeight={700}>
+        <Box
+          sx={{
+            borderRadius: '100%',
+            backgroundColor: ({ palette }) => palette.text.disabled,
+            minWidth: '6px',
+            minHeight: '6px',
+            flexShrink: 0,
+            marginRight: 1,
+          }}
+        />
+        Campaigns <Chip variant="outlined" sx={{ borderRadius: '16px' }} label="soon" />
       </Typography>
     ),
     disabled: true,
@@ -29,11 +53,15 @@ const CampaignTabs = ({ onChange, selectedTabIdx }: { onChange: (tab: number) =>
         variant="scrollable"
         value={selectedTabIdx}
         aria-label="Vertical tabs example"
-        sx={{ borderRight: 1, borderColor: 'divider' }}
+        sx={{ border: 1, borderColor: 'divider', borderRadius: '6px' }}
         onChange={(_, value) => onChange(value)}
       >
         {CAMPAIGN_TABS.map((tab, tabIdx) => (
-          <Tab key={tabIdx} {...tab} />
+          <Tab
+            sx={{ textTransform: 'none', fontWeight: 700, textAlign: 'left', alignItems: 'start' }}
+            key={tabIdx}
+            {...tab}
+          />
         ))}
       </Tabs>
     </Box>

--- a/src/components/Points/CampaignTabs.tsx
+++ b/src/components/Points/CampaignTabs.tsx
@@ -1,6 +1,6 @@
 import Tabs from '@mui/material/Tabs'
 import Tab from '@mui/material/Tab'
-import { Box, Chip, Typography } from '@mui/material'
+import { Box, Chip, Tooltip, Typography } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 import css from './styles.module.css'
 
@@ -8,16 +8,18 @@ const CAMPAIGN_TABS = [
   {
     label: (
       <Typography display="flex" flexDirection="row" gap={1} alignItems="center" fontWeight={700}>
-        <Box
-          sx={{
-            borderRadius: '100%',
-            backgroundColor: ({ palette }) => palette.primary.main,
-            minWidth: '6px',
-            minHeight: '6px',
-            flexShrink: 0,
-            marginRight: 1,
-          }}
-        />
+        <Tooltip title="This campaign is active now" arrow>
+          <Box
+            sx={{
+              borderRadius: '100%',
+              backgroundColor: ({ palette }) => palette.primary.main,
+              minWidth: '6px',
+              minHeight: '6px',
+              flexShrink: 0,
+              marginRight: 1,
+            }}
+          />
+        </Tooltip>
         Global
       </Typography>
     ),

--- a/src/components/Points/TotalPoints.tsx
+++ b/src/components/Points/TotalPoints.tsx
@@ -27,7 +27,7 @@ export const TotalPoints = () => {
         )}
         <Box display="flex" flexDirection="row" gap={1} alignItems="center">
           <Typography color="text.secondary">Your total points</Typography>
-          <Tooltip title="All points collected form capaigns and regular Safe activities" arrow>
+          <Tooltip title="All points collected form campaigns and regular Safe activities" arrow>
             <InfoOutlined fontSize="small" sx={{ color: ({ palette }) => palette.text.secondary }} />
           </Tooltip>
         </Box>

--- a/src/components/Points/TotalPoints.tsx
+++ b/src/components/Points/TotalPoints.tsx
@@ -1,0 +1,37 @@
+import { useGlobalCampaignId } from '@/hooks/useGlobalCampaignId'
+import { useOwnCampaignRank } from '@/hooks/useLeaderboard'
+import { InfoOutlined } from '@mui/icons-material'
+import { Box, Skeleton, Stack, Tooltip, Typography } from '@mui/material'
+import { useMemo } from 'react'
+import PaperContainer from '../PaperContainer'
+import PointsCounter from '../PointsCounter'
+
+export const TotalPoints = () => {
+  const globalCampaignId = useGlobalCampaignId()
+  const ownRank = useOwnCampaignRank(globalCampaignId)
+
+  const totalPoints = useMemo(
+    () => (ownRank.isLoading ? undefined : ownRank.data?.totalBoostedPoints ?? 0),
+    [ownRank.data?.totalBoostedPoints, ownRank.isLoading],
+  )
+
+  return (
+    <PaperContainer>
+      <Stack alignItems="center" gap={1.5} textAlign="center">
+        {totalPoints !== undefined ? (
+          <PointsCounter value={totalPoints} variant="h2" fontWeight={700} fontSize="44px" color="primary" />
+        ) : (
+          <Typography minWidth="30px">
+            <Skeleton />
+          </Typography>
+        )}
+        <Box display="flex" flexDirection="row" gap={1} alignItems="center">
+          <Typography color="text.secondary">Your total points</Typography>
+          <Tooltip title="All points collected form capaigns and regular Safe activities" arrow>
+            <InfoOutlined fontSize="small" sx={{ color: ({ palette }) => palette.text.secondary }} />
+          </Tooltip>
+        </Box>
+      </Stack>
+    </PaperContainer>
+  )
+}

--- a/src/components/Points/index.tsx
+++ b/src/components/Points/index.tsx
@@ -1,7 +1,7 @@
 import { GLOBAL_CAMPAIGN_IDS } from '@/config/constants'
 import { useCampaignInfo, useCampaignPage } from '@/hooks/useCampaigns'
 import { useChainId } from '@/hooks/useChainId'
-import { Grid, Typography, Stack, Box, SvgIcon, Divider } from '@mui/material'
+import { Grid, Typography, Stack, Box, SvgIcon, Divider, useMediaQuery } from '@mui/material'
 import { useEffect, useMemo, useState } from 'react'
 import { ExternalLink } from '../ExternalLink'
 import PaperContainer from '../PaperContainer'
@@ -14,6 +14,7 @@ import CampaignTabs from './CampaignTabs'
 import StarIcon from '@/public/images/leaderboard-title-star.svg'
 import css from './styles.module.css'
 import { TotalPoints } from './TotalPoints'
+import { useTheme } from '@mui/material/styles'
 
 const Points = () => {
   const campaignPage = useCampaignPage(20)
@@ -47,6 +48,8 @@ const Points = () => {
     () => globalCampaign?.resourceId === selectedCampaignId,
     [globalCampaign?.resourceId, selectedCampaignId],
   )
+  const theme = useTheme()
+  const isSmallScreen = useMediaQuery(theme.breakpoints.down('lg'))
 
   return (
     <Grid container spacing={3} direction="row">
@@ -59,22 +62,26 @@ const Points = () => {
 
       <Grid item xs={12} lg={8}>
         <Stack spacing={3}>
+          {isSmallScreen && <TotalPoints />}
           <PaperContainer>
             <Stack direction="row" spacing={2}>
-              <SvgIcon component={StarIcon} inheritViewBox sx={{ width: '27px', height: '27px' }} />
+              {!isSmallScreen && <SvgIcon component={StarIcon} inheritViewBox sx={{ width: '27px', height: '27px' }} />}
               <Stack spacing={1}>
                 <Typography variant="h5" fontWeight={700} fontSize="24px">
                   Points activity feed
                 </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  Earn points by engaging with Safe and our campaign partners. Depending on the campaign, you&apos;ll be
-                  rewarded for various activities suggested by our partners. You can also earn points for Regular Safe
-                  Activities.
-                </Typography>
+
+                {!isSmallScreen && (
+                  <Typography variant="body2" color="text.secondary">
+                    Earn points by engaging with Safe and our campaign partners. Depending on the campaign, you&apos;ll
+                    be rewarded for various activities suggested by our partners. You can also earn points for Regular
+                    Safe Activities.
+                  </Typography>
+                )}
               </Stack>
             </Stack>
-            <Divider sx={{ mt: 4 }} />
-            <Stack direction={{ lg: 'row', md: 'column' }} spacing={4} mt={5}>
+            <Divider />
+            <Stack direction={{ lg: 'row', md: 'column' }} spacing={4}>
               <CampaignTabs onChange={onTabChange} selectedTabIdx={selectedTab} />
               <Box width="100%">
                 <Stack
@@ -109,7 +116,7 @@ const Points = () => {
       </Grid>
       <Grid item xs={12} lg={4}>
         <Stack spacing={3} justifyContent="stretch" height="100%">
-          <TotalPoints />
+          {!isSmallScreen && <TotalPoints />}
           <CampaignInfo campaign={campaign} />
         </Stack>
       </Grid>

--- a/src/components/Points/index.tsx
+++ b/src/components/Points/index.tsx
@@ -74,8 +74,8 @@ const Points = () => {
                 {!isSmallScreen && (
                   <Typography variant="body2" color="text.secondary">
                     Earn points by engaging with Safe and our campaign partners. Depending on the campaign, you&apos;ll
-                    be rewarded for various activities suggested by our partners. You can also earn points for Regular
-                    Safe Activities.
+                    be rewarded for various activities suggested by our partners. You can also earn points for regular
+                    Safe activities.
                   </Typography>
                 )}
               </Stack>

--- a/src/components/Points/index.tsx
+++ b/src/components/Points/index.tsx
@@ -1,7 +1,7 @@
 import { GLOBAL_CAMPAIGN_IDS } from '@/config/constants'
 import { useCampaignInfo, useCampaignPage } from '@/hooks/useCampaigns'
 import { useChainId } from '@/hooks/useChainId'
-import { Grid, Typography, Stack, Box, SvgIcon } from '@mui/material'
+import { Grid, Typography, Stack, Box, SvgIcon, Divider } from '@mui/material'
 import { useEffect, useMemo, useState } from 'react'
 import { ExternalLink } from '../ExternalLink'
 import PaperContainer from '../PaperContainer'
@@ -73,7 +73,8 @@ const Points = () => {
                 </Typography>
               </Stack>
             </Stack>
-            <Stack direction={{ lg: 'row', md: 'column' }} spacing={4} mt={9}>
+            <Divider sx={{ mt: 4 }} />
+            <Stack direction={{ lg: 'row', md: 'column' }} spacing={4} mt={5}>
               <CampaignTabs onChange={onTabChange} selectedTabIdx={selectedTab} />
               <Box width="100%">
                 <Stack

--- a/src/components/Points/index.tsx
+++ b/src/components/Points/index.tsx
@@ -1,8 +1,8 @@
 import { GLOBAL_CAMPAIGN_IDS } from '@/config/constants'
 import { useCampaignInfo, useCampaignPage } from '@/hooks/useCampaigns'
 import { useChainId } from '@/hooks/useChainId'
-import { Grid, Typography, Stack, Box } from '@mui/material'
-import { useEffect, useState } from 'react'
+import { Grid, Typography, Stack, Box, SvgIcon } from '@mui/material'
+import { useEffect, useMemo, useState } from 'react'
 import { ExternalLink } from '../ExternalLink'
 import PaperContainer from '../PaperContainer'
 import SafePassDisclaimer from '../SafePassDisclaimer'
@@ -11,7 +11,9 @@ import { CampaignInfo } from './CampaignInfo'
 import { CampaignLeaderboard } from './CampaignLeaderboard'
 import { CampaignSelector } from './CampaignSelector'
 import CampaignTabs from './CampaignTabs'
+import StarIcon from '@/public/images/leaderboard-title-star.svg'
 import css from './styles.module.css'
+import { TotalPoints } from './TotalPoints'
 
 const Points = () => {
   const campaignPage = useCampaignPage(20)
@@ -41,6 +43,11 @@ const Points = () => {
     }
   }
 
+  const isGlobalCampaign = useMemo(
+    () => globalCampaign?.resourceId === selectedCampaignId,
+    [globalCampaign?.resourceId, selectedCampaignId],
+  )
+
   return (
     <Grid container spacing={3} direction="row">
       <Grid item xs={12} mt={4} mb={1} className={css.pageTitle} display="flex" flexDirection="row" alignItems="center">
@@ -53,7 +60,20 @@ const Points = () => {
       <Grid item xs={12} lg={8}>
         <Stack spacing={3}>
           <PaperContainer>
-            <Stack direction={{ lg: 'row', md: 'column' }} spacing={3}>
+            <Stack direction="row" spacing={2}>
+              <SvgIcon component={StarIcon} inheritViewBox sx={{ width: '27px', height: '27px' }} />
+              <Stack spacing={1}>
+                <Typography variant="h5" fontWeight={700} fontSize="24px">
+                  Points activity feed
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Earn points by engaging with Safe and our campaign partners. Depending on the campaign, you&apos;ll be
+                  rewarded for various activities suggested by our partners. You can also earn points for Regular Safe
+                  Activities.
+                </Typography>
+              </Stack>
+            </Stack>
+            <Stack direction={{ lg: 'row', md: 'column' }} spacing={4} mt={9}>
               <CampaignTabs onChange={onTabChange} selectedTabIdx={selectedTab} />
               <Box width="100%">
                 <Stack
@@ -65,10 +85,9 @@ const Points = () => {
                   minHeight="60px"
                 >
                   <Box width="100%">
-                    <Typography variant="h5" fontWeight={700}>
-                      Points activity feed
+                    <Typography variant="h6" fontWeight={700} fontSize="20px">
+                      {isGlobalCampaign ? 'Global' : campaign?.name}
                     </Typography>
-                    <Typography variant="subtitle2">Your points are updated weekly.</Typography>
                   </Box>
                   {selectedTab > 0 && (
                     <CampaignSelector
@@ -89,6 +108,7 @@ const Points = () => {
       </Grid>
       <Grid item xs={12} lg={4}>
         <Stack spacing={3} justifyContent="stretch" height="100%">
+          <TotalPoints />
           <CampaignInfo campaign={campaign} />
         </Stack>
       </Grid>

--- a/src/components/Points/styles.module.css
+++ b/src/components/Points/styles.module.css
@@ -18,3 +18,12 @@
   transform: translate(-50%);
   pointer-events: none;
 }
+
+.comingSoon {
+  background-color: #303033;
+  border-radius: 4px;
+  padding: 4px 8px;
+  margin-left: 8px;
+  border: none;
+  font-weight: 400;
+}

--- a/src/components/TokenLocking/ActivityRewardsInfo.tsx
+++ b/src/components/TokenLocking/ActivityRewardsInfo.tsx
@@ -75,7 +75,7 @@ export const ActivityRewardsInfo = () => {
               description="Lock your tokens early to increase your earning power. The earlier and more you lock, the bigger your points multiplier. Geographic & other limitations apply (see disclaimer below)."
             />
             <Step
-              active={false}
+              active={true}
               title="Get activity points"
               description="Earn points by using your Safe Account. Your points are multiplied by the boost."
             />

--- a/src/hooks/useLatestCampaignUpdate.ts
+++ b/src/hooks/useLatestCampaignUpdate.ts
@@ -1,0 +1,51 @@
+import { useAddress } from './useAddress'
+import { PaginatedResult, useGatewayBaseUrl } from './useGatewayBaseUrl'
+import useSWR from 'swr'
+import { useMemo } from 'react'
+
+type CampaignUpdate = {
+  startDate: string
+  endDate: string
+  holder: string
+  boost: number
+  totalPoints: number
+  totalBoostedPoints: number
+}
+
+export const useLatestCampaignUpdate = (resourceId: string | undefined) => {
+  const address = useAddress()
+  const gatewayBaseUrl = useGatewayBaseUrl()
+
+  const getKey = (resourceId: string | undefined) => {
+    if (!resourceId || !address) {
+      return null
+    }
+    // Load newest page only
+    return `${gatewayBaseUrl}/v1/community/campaigns/${resourceId}/activities/?holder=${address}`
+  }
+
+  const { data, isLoading } = useSWR(
+    getKey(resourceId),
+    async (url: string) => {
+      return await fetch(url).then((resp) => {
+        if (resp.ok) {
+          return resp.json() as Promise<PaginatedResult<CampaignUpdate>>
+        } else {
+          throw new Error('Error fetching campaign update.')
+        }
+      })
+    },
+    {
+      errorRetryCount: 1,
+    },
+  )
+
+  // Only return newest entry
+  const newestUpdate = useMemo(() => {
+    if (data && data.results.length > 0) {
+      return data.results[0]
+    }
+  }, [data])
+
+  return { data: newestUpdate, isLoading }
+}


### PR DESCRIPTION
## What this PR changes
- Show  last update separately from total points
  - Fetch last weeks data
  - show last weeks data in activity feed
  - Show the total global points on the top right
- Redesign components
  - Tab navigation
  - Activity feed

## Screenshot
![Screenshot 2024-06-18 at 16 37 20](https://github.com/safe-global/safe-dao-governance-app/assets/2670790/ff1318fc-204f-4d1f-9f34-f2054391b3fd)
