### PR TITLE
fix: show latest campaign update

### DIFF
--- a/src/components/Points/ActivityPointsFeed.tsx
+++ b/src/components/Points/ActivityPointsFeed.tsx
@@ -184,7 +184,7 @@ export const ActivityPointsFeed = ({ campaign }: { campaign?: Campaign }) => {
           )}
         </DataWrapper>
         <Typography mt={6} alignSelf="center" color="text.secondary">
-          Your points are updated weekly.
+          Points are updated weekly.
         </Typography>
         <Typography mt={-2} alignSelf="center" color="text.secondary">
           Last update: {formatDate(new Date(campaign.lastUpdated))}

--- a/src/components/Points/ActivityPointsFeed.tsx
+++ b/src/components/Points/ActivityPointsFeed.tsx
@@ -143,7 +143,7 @@ export const ActivityPointsFeed = ({ campaign }: { campaign?: Campaign }) => {
     <>
       <BorderedBox key={campaign?.resourceId}>
         <DataWrapper>
-          <Typography color="text.secondary">Last drop</Typography>
+          <Typography color="text.secondary">Your last drop</Typography>
           {latestUpdate && (
             <Typography color="text.secondary">
               {formatDate(new Date(latestUpdate.startDate))} - {formatDate(new Date(latestUpdate.endDate))}
@@ -185,6 +185,9 @@ export const ActivityPointsFeed = ({ campaign }: { campaign?: Campaign }) => {
         </DataWrapper>
         <Typography mt={6} alignSelf="center" color="text.secondary">
           Your points are updated weekly.
+        </Typography>
+        <Typography mt={-2} alignSelf="center" color="text.secondary">
+          Last update: {formatDate(new Date(campaign.lastUpdated))}
         </Typography>
         <Barcode className={css.barcode} />
       </BorderedBox>


### PR DESCRIPTION
## What this PR changes
- Shows the latest update of the campaign separately
- Rephrases "last drop" to "Your last drop" as it reflects the last drop the Safe was a part of. 

## Screenshot
<img width="618" alt="Screenshot 2024-06-24 at 16 18 03" src="https://github.com/safe-global/safe-dao-governance-app/assets/2670790/6e5594ec-bf4d-48bb-8b15-2361566a191f">
