### PR TITLE
Analytics: campaign events

### DIFF
--- a/src/analytics/navigation.ts
+++ b/src/analytics/navigation.ts
@@ -23,4 +23,10 @@ export const NAVIGATION_EVENTS = {
   OPEN_POINTS: {
     action: 'Open points page',
   },
+  OPEN_CAMPAIGN: {
+    action: 'Open campaign',
+  },
+  OPEN_EXTERNAL_LINK: {
+    action: 'Open external link',
+  },
 }

--- a/src/components/ExternalLink/index.tsx
+++ b/src/components/ExternalLink/index.tsx
@@ -3,6 +3,8 @@ import type { LinkProps } from '@mui/material'
 import { CSSProperties, forwardRef, ReactElement } from 'react'
 
 import LinkIcon from '@/public/images/link.svg'
+import Track from '../Track'
+import { NAVIGATION_EVENTS } from '@/analytics/navigation'
 
 const styles: CSSProperties = {
   marginLeft: '4px',
@@ -13,7 +15,7 @@ export const ExternalLink = forwardRef<
   LinkProps & { href: string; icon?: boolean; variant?: string }
 >(({ children, icon = true, variant = 'link', href, ...props }, ref): ReactElement => {
   return (
-    <>
+    <Track {...NAVIGATION_EVENTS.OPEN_EXTERNAL_LINK} label={href}>
       {variant === 'button' ? (
         <Button rel="noopener noreferrer" variant="outlined" href={href} target="_blank" sx={props.sx}>
           {children}
@@ -33,7 +35,7 @@ export const ExternalLink = forwardRef<
           {icon && <LinkIcon style={styles} />}
         </Link>
       )}
-    </>
+    </Track>
   )
 })
 ExternalLink.displayName = 'ExternalLink'

--- a/src/components/Points/CampaignTabs.tsx
+++ b/src/components/Points/CampaignTabs.tsx
@@ -2,9 +2,11 @@ import Tabs from '@mui/material/Tabs'
 import Tab from '@mui/material/Tab'
 import { Box, Button, Tooltip, Typography } from '@mui/material'
 import { useCampaignsPaginated } from '@/hooks/useCampaigns'
-import { ReactNode, useMemo } from 'react'
+import { ReactNode, SyntheticEvent, useCallback, useMemo } from 'react'
 import { useGlobalCampaignId } from '@/hooks/useGlobalCampaignId'
 import { CampaignTitle } from './CampaignTitle'
+import { NAVIGATION_EVENTS } from '@/analytics/navigation'
+import { trackSafeAppEvent } from '@/utils/analytics'
 
 type CampaignTabProps = {
   label: ReactNode
@@ -56,6 +58,14 @@ const CampaignTabs = ({
     value: globalCampaign,
   }
 
+  const handleChange = useCallback(
+    (_: SyntheticEvent, value: any) => {
+      trackSafeAppEvent(NAVIGATION_EVENTS.OPEN_CAMPAIGN.action, value)
+      onChange(value)
+    },
+    [onChange],
+  )
+
   return (
     <Box padding="8px 0px">
       <Tabs
@@ -64,7 +74,7 @@ const CampaignTabs = ({
         value={selectedCampaignId}
         aria-label="Vertical tabs example"
         sx={{ border: 1, borderColor: 'divider', borderRadius: '6px', pt: 2, pb: 2, minWidth: '286px' }}
-        onChange={(_, value) => onChange(value)}
+        onChange={handleChange}
       >
         <Tab
           sx={{

--- a/src/components/Points/index.tsx
+++ b/src/components/Points/index.tsx
@@ -33,9 +33,9 @@ const Points = () => {
     <Grid container spacing={3} direction="row">
       <Grid item xs={12} mt={4} mb={1} className={css.pageTitle} display="flex" flexDirection="row" alignItems="center">
         <Typography variant="h2">{'Get rewards with Safe{Pass}'}</Typography>
-        <ExternalLink href="https://safe.global/pass" ml="auto">
-          {'What is Safe{Pass}'}
-        </ExternalLink>
+        <Box ml="auto">
+          <ExternalLink href="https://safe.global/pass">{'What is Safe{Pass}'}</ExternalLink>
+        </Box>
       </Grid>
 
       <Grid item xs={12} lg={8}>

--- a/src/components/TokenLocking/LockTokenWidget.tsx
+++ b/src/components/TokenLocking/LockTokenWidget.tsx
@@ -24,7 +24,6 @@ import MilesReceipt from '@/components/TokenLocking/MilesReceipt'
 import { BaseTransaction, useTxSender } from '@/hooks/useTxSender'
 import { useSafeTokenLockingAllowance } from '@/hooks/useSafeTokenBalance'
 import { useStartDate } from '@/hooks/useStartDates'
-import { NAVIGATION_EVENTS } from '@/analytics/navigation'
 import { ExternalLink } from '../ExternalLink'
 import { formatAmount } from '@/utils/formatters'
 
@@ -168,9 +167,7 @@ export const LockTokenWidget = ({ safeBalance }: { safeBalance: BigNumberish | u
             Lock tokens to boost your points
           </Typography>
         </Box>
-        <Track {...NAVIGATION_EVENTS.OPEN_BOOST_INFO}>
-          <ExternalLink href={SAFE_PASS_HELP_ARTICLE_URL}>More about the boost</ExternalLink>
-        </Track>
+        <ExternalLink href={SAFE_PASS_HELP_ARTICLE_URL}>More about the boost</ExternalLink>
       </Box>
       <Stack
         spacing={3}

--- a/src/components/TokenLocking/index.tsx
+++ b/src/components/TokenLocking/index.tsx
@@ -1,4 +1,4 @@
-import { Grid, Stack, Typography } from '@mui/material'
+import { Box, Grid, Stack, Typography } from '@mui/material'
 import { useSafeTokenBalance } from '@/hooks/useSafeTokenBalance'
 import { Leaderboard } from './Leaderboard'
 import { CurrentStats } from './CurrentStats'
@@ -23,9 +23,9 @@ const TokenLocking = () => {
     <Grid container spacing={3} direction="row-reverse">
       <Grid item xs={12} mt={4} mb={1} className={css.pageTitle} display="flex" flexDirection="row" alignItems="center">
         <Typography variant="h2">{'Get rewards with Safe{Pass}'}</Typography>
-        <ExternalLink href="https://safe.global/pass" ml="auto">
-          {'What is Safe{Pass}'}
-        </ExternalLink>
+        <Box ml="auto">
+          <ExternalLink href="https://safe.global/pass">{'What is Safe{Pass}'}</ExternalLink>
+        </Box>
       </Grid>
       <Grid item xs={12} lg={4}>
         <Stack spacing={3} justifyContent="stretch" height="100%">

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -6,7 +6,7 @@ export const trackSafeAppEvent = (action: string, label?: string) => {
       category: SAFE_APPS_ANALYTICS_CATEGORY,
       action,
       label,
-      safeAppName: 'Safe{Explorers}',
+      safeAppName: 'Safe{Pass}',
     },
     '*',
   )


### PR DESCRIPTION
## What this PR is about
Adds new events for tracking campaigns and external links:

- `ExternalLink` will always track and add the `href` as `label`
- Tracking for `CampaignTab` navigation