### PR TITLE
fix: Show error message in case the fingerprint request fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "safe-dao-governance-app",
   "homepage": "https://github.com/safe-global/safe-dao-governance-app",
   "license": "GPL-3.0",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "scripts": {
     "build": "next build && next export",
     "lint": "tsc && next lint",

--- a/src/components/Points/index.tsx
+++ b/src/components/Points/index.tsx
@@ -52,7 +52,7 @@ const Points = () => {
       })
       .catch((err) =>
         setFingerprintError(
-          'Something went wrong while checking your eligibility. Make sure to turn off any AdBlocker before accessing this site.',
+          "It looks like some content isn't loading correctly. Please try disabling your AdBlocker and reload the page.",
         ),
       )
   }, [])
@@ -132,6 +132,14 @@ const Points = () => {
         </Grid>
       </Grid>
 
+      {fingerprintError && (
+        <Grid container>
+          <Grid item width={1} mb={2}>
+            <Alert severity="error">{fingerprintError}</Alert>
+          </Grid>
+        </Grid>
+      )}
+
       <Grid container>
         <Grid item width={1}>
           <PaperContainer
@@ -143,23 +151,21 @@ const Points = () => {
             }}
           >
             {loading ? (
-              <>
-                <CircularProgress color="inherit" />
-                {fingerprintError && (
-                  <Alert severity="error" sx={{ maxWidth: '500px' }}>
-                    {fingerprintError}
-                  </Alert>
-                )}
-              </>
+              <CircularProgress color="inherit" />
             ) : hasSAPAllocation ? (
               <Grid container>
                 <Grid item xs={12} lg={7}>
                   <Stack gap={2} alignItems="flex-start" p={4}>
                     <Typography variant="h3" fontWeight={700} fontSize="32px">
                       {isSAPClaimed ? 'Congratulations, you claimed your rewards!' : 'Rewards Await! 🏆'}
-                      <br />
-                      <br />
-                      {isSAPClaimed && <TokenAmount amount={totalSAP.allocation} label="Claimed" loading={false} />}
+
+                      {isSAPClaimed && (
+                        <>
+                          <br />
+                          <br />
+                          <TokenAmount amount={totalSAP.allocation} label="Claimed" loading={false} />
+                        </>
+                      )}
                     </Typography>
 
                     {!isSAPClaimed && (

--- a/src/components/Points/index.tsx
+++ b/src/components/Points/index.tsx
@@ -27,6 +27,7 @@ import { TokenAmount } from '@/components/TokenAmount'
 
 const Points = () => {
   const [sealedResult, setSealedResult] = useState<SealedRequest>()
+  const [fingerprintError, setFingerprintError] = useState<string>()
   const { data: eligibility, isLoading } = useUnsealedResult(sealedResult)
   const { sdk, safe } = useSafeAppsSDK()
   const globalCampaignId = useGlobalCampaignId()
@@ -46,9 +47,14 @@ const Points = () => {
     fpPromise
       .then((fp) => fp.get({ extendedResult: true }))
       .then((fingerprint) => {
+        setFingerprintError(undefined)
         setSealedResult({ requestId: fingerprint.requestId, sealedResult: fingerprint.sealedResult })
       })
-      .catch((err) => console.error('Failed to fetch sealed client results: ', err))
+      .catch((err) =>
+        setFingerprintError(
+          'Something went wrong while checking your eligibility. Make sure to turn off any AdBlocker before accessing this site.',
+        ),
+      )
   }, [])
 
   const startClaiming = async () => {
@@ -137,7 +143,14 @@ const Points = () => {
             }}
           >
             {loading ? (
-              <CircularProgress color="inherit" />
+              <>
+                <CircularProgress color="inherit" />
+                {fingerprintError && (
+                  <Alert severity="error" sx={{ maxWidth: '500px' }}>
+                    {fingerprintError}
+                  </Alert>
+                )}
+              </>
             ) : hasSAPAllocation ? (
               <Grid container>
                 <Grid item xs={12} lg={7}>


### PR DESCRIPTION
## What it solves

In case a user has an adblock active it can make the fingerprint request fail

## How it solves it

- If there is an error during the fingerprint request show an error message to the user

## Screenshots
<img width="1456" alt="Screenshot 2024-12-05 at 22 42 03" src="https://github.com/user-attachments/assets/95be1cb0-5bb0-46cb-bd75-0324df839571">
