### PR TITLE
fix: add least-privilege permissions to workflows

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -21,7 +21,7 @@ jobs:
           repository: safe-global/github-reusable-workflows
           token: ${{ secrets.REUSABLE_WORKFLOWS_TOKEN }}
           path: reusable-workflows
-          ref: f72a861e898dd2d539a0598a1fb43a8ea801ebd1 # main 2026-05-27 (signatures branch)
+          ref: c4fd58f9c721aca09b841c8035ce1d115ed5f3c3 # v2.4.18
       - name: 'CLA Assistant'
         uses: ./reusable-workflows/actions/cla
         with:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -19,7 +19,7 @@ jobs:
       - name: 'CLA Assistant'
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         # Beta Release
-        uses: contributor-assistant/github-action@v2.2.0
+        uses: contributor-assistant/github-action@b2a7f9fb90217ea0b8a0c95c288221457be4a31f  # v2.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # the below token should have repo scope and must be manually added by you in the repository's secret

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -6,6 +6,12 @@ on:
   pull_request_target:
     types: [opened, closed, synchronize]
 
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+  statuses: write
+
 jobs:
   CLAAssistant:
     runs-on: ubuntu-latest

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,46 +1,30 @@
 name: 'CLA Assistant'
-
 on:
   issue_comment:
     types: [created]
   pull_request_target:
     types: [opened, closed, synchronize]
 
-permissions:
-  actions: write
-  contents: read
-  pull-requests: write
-  statuses: write
+permissions: {}
 
 jobs:
-  CLAAssistant:
+  CLAssistant:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     steps:
-      - name: 'CLA Assistant'
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        # Beta Release
-        uses: contributor-assistant/github-action@b2a7f9fb90217ea0b8a0c95c288221457be4a31f  # v2.2.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # the below token should have repo scope and must be manually added by you in the repository's secret
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ACCESS_TOKEN }}
+      - name: Checkout reusable workflows
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          path-to-signatures: 'signatures/version1/cla.json'
-          path-to-document: 'https://safe.global/cla/' # e.g. a CLA or a DCO document
-          # branch should not be protected
-          branch: 'main'
-          # user names of users allowed to contribute without CLA
+          repository: safe-global/github-reusable-workflows
+          token: ${{ secrets.REUSABLE_WORKFLOWS_TOKEN }}
+          path: reusable-workflows
+          ref: f72a861e898dd2d539a0598a1fb43a8ea801ebd1 # main 2026-05-27 (signatures branch)
+      - name: 'CLA Assistant'
+        uses: ./reusable-workflows/actions/cla
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          personal-access-token: ${{ secrets.CLA_ACCESS_TOKEN }}
           allowlist: lukasschor,mikheevm,rmeissner,Uxio0,dasanra,francovenica,tschubotz,luarx,bot*,yagopv,usame-algan,schmanu
-
-          # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
-          # enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
-          remote-organization-name: 'safe-global'
-          # enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
-          remote-repository-name: 'cla-signatures'
-          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
-          #signed-commit-message: 'For example: $contributorName has signed the CLA in #$pullRequestNo'
-          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
-          #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
-          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
-          #lock-pullrequest-aftermerge: false - if you don't want this bot to automatically lock the pull request after merging (default - true)
-          #use-dco-flag: true - If you are using DCO instead of CLA

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy release
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
 
       - uses: ./.github/workflows/yarn
 
@@ -22,7 +22,7 @@ jobs:
           is-production: true
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838  # v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
       # Post a PR comment before deploying
       - name: Post a comment while building
         if: github.event.number
-        uses: mshick/add-pr-comment@v2
+        uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc  # v2
         with:
           message-id: praul
           message: |
@@ -35,7 +35,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           repo-token-user-login: 'github-actions[bot]'
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
 
       - uses: ./.github/workflows/yarn
 
@@ -45,7 +45,7 @@ jobs:
           is-production: false
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838  # v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -85,7 +85,7 @@ jobs:
       # Comnment
       - name: Post a deployment link in the PR
         if: always() && github.event.number
-        uses: mshick/add-pr-comment@v2
+        uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc  # v2
         with:
           message-id: praul
           message: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,11 +12,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
 
     name: Deploy to dev/staging
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.8.0
+        uses: styfle/cancel-workflow-action@3d86a7cc43670094ac248017207be0295edbc31d  # 0.8.0
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
 
       - uses: ./.github/workflows/yarn
 
-      - uses: Maggi64/eslint-plus-action@master
+      - uses: Maggi64/eslint-plus-action@aac8f0f16d205b3760edf331c28a9ce12bdd741f  # master
         with:
           npmInstall: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,12 @@
 name: 'Lint'
 on: [pull_request]
 
+permissions:
+  actions: write
+  checks: write
+  contents: read
+  pull-requests: write
+
 jobs:
   eslint:
     runs-on: ubuntu-latest

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2
         if: github.event.pull_request.merged == true
         with:
           fetch-depth: 0
@@ -37,7 +37,7 @@ jobs:
 
       - name: GitHub release
         if: success()
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e  # v1
         id: create_release
         with:
           draft: true

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -6,6 +6,9 @@ on:
       - main
     types: [closed]
 
+permissions:
+  contents: write
+
 jobs:
   tag-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  checks: write
+  contents: read
+  pull-requests: write
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
 
       - uses: ./.github/workflows/yarn
 
@@ -27,7 +27,7 @@ jobs:
         run: 'yarn test:ci'
 
       - name: Comment in failing tests
-        uses: mattallty/jest-github-action@v1.0.3
+        uses: mattallty/jest-github-action@43bbcd073fa43a927322f188220b6592acae003b  # v1.0.3
         if: failure()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/yarn/action.yml
+++ b/.github/workflows/yarn/action.yml
@@ -7,12 +7,12 @@ runs:
   steps:
     # `hardhat compile` has issues with the latest version of Node
     # https://github.com/NomicFoundation/hardhat/issues/3877
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610  # v3
       with:
         node-version: 18.15.0
 
     - name: Yarn cache
-      uses: actions/cache@v3
+      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c  # v3
       with:
         path: '**/node_modules'
         key: safe-dao-governance-app-modules-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
Resolves the `actions/missing-workflow-permissions` warnings on all five workflows by adding least-privilege `permissions` blocks.

- `cla.yml`: `pull-requests`/`statuses: write` for the CLA bot to comment/set status, `actions: write` so it can re-trigger itself. Signatures go to the remote repo via `PERSONAL_ACCESS_TOKEN`, not `GITHUB_TOKEN`.
- `deploy-release.yml`: `contents: read` for checkout. S3 deploy uses the AWS access-key secrets, not `GITHUB_TOKEN`.
- `deploy.yml`: hoist the existing `pull-requests: write` job-level perm to workflow level and add `contents: read`. Removes the now-redundant job-level block.
- `lint.yml`: `actions: write` (`styfle/cancel-workflow-action`), `checks: write` + `pull-requests: write` (`Maggi64/eslint-plus-action`), `contents: read`.
- `tag-release.yml`: `contents: write` to push the tag and create the release.
- `test.yml`: `checks: write` + `pull-requests: write` (`mattallty/jest-github-action`), `contents: read`.
