### PR TITLE
feat: Migrate deploy workflows to OIDC and pin all action SHAs

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -13,7 +13,7 @@ jobs:
       - name: 'CLA Assistant'
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         # Beta Release
-        uses: contributor-assistant/github-action@v2.2.0
+        uses: contributor-assistant/github-action@b2a7f9fb90217ea0b8a0c95c288221457be4a31f # v2.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # the below token should have repo scope and must be manually added by you in the repository's secret

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -8,8 +8,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
     name: Deploy release
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: ./.github/workflows/yarn
 
@@ -19,10 +22,9 @@ jobs:
           is-production: true
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_STAGING }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
 
       # Script to upload release files

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
+      id-token: write
       pull-requests: write
 
     name: Deploy to dev/staging
@@ -24,7 +26,7 @@ jobs:
       # Post a PR comment before deploying
       - name: Post a comment while building
         if: github.event.number
-        uses: mshick/add-pr-comment@v2
+        uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2
         with:
           message-id: praul
           message: |
@@ -33,7 +35,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           repo-token-user-login: 'github-actions[bot]'
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: ./.github/workflows/yarn
 
@@ -43,10 +45,9 @@ jobs:
           is-production: false
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_STAGING }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
 
       # Staging
@@ -83,7 +84,7 @@ jobs:
       # Comnment
       - name: Post a deployment link in the PR
         if: always() && github.event.number
-        uses: mshick/add-pr-comment@v2
+        uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2
         with:
           message-id: praul
           message: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,14 +6,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.8.0
+        uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # 0.12.1
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: ./.github/workflows/yarn
 
-      - uses: Maggi64/eslint-plus-action@master
+      - uses: Maggi64/eslint-plus-action@972d934f4b5b41945c4f489dc49717c80eb8be4c # master
         with:
           npmInstall: false

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: github.event.pull_request.merged == true
         with:
           fetch-depth: 0
@@ -34,7 +34,7 @@ jobs:
 
       - name: GitHub release
         if: success()
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
         id: create_release
         with:
           draft: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: ./.github/workflows/yarn
 
@@ -22,7 +22,7 @@ jobs:
         run: 'yarn test:ci'
 
       - name: Comment in failing tests
-        uses: mattallty/jest-github-action@v1.0.3
+        uses: mattallty/jest-github-action@43bbcd073fa43a927322f188220b6592acae003b # v1.0.3
         if: failure()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/yarn/action.yml
+++ b/.github/workflows/yarn/action.yml
@@ -7,12 +7,12 @@ runs:
   steps:
     # `hardhat compile` has issues with the latest version of Node
     # https://github.com/NomicFoundation/hardhat/issues/3877
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: 18.15.0
 
     - name: Yarn cache
-      uses: actions/cache@v3
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: '**/node_modules'
         key: safe-dao-governance-app-modules-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
Replaces static `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` with OIDC-based authentication across both deploy workflows. Production deployment is triggered via webhook to GitLab CI, not directly from GitHub Actions.

  **deploy.yml / deploy-release.yml**
  - Add `permissions: contents: read` + `id-token: write`
  - Replace static key inputs with `AWS_ROLE_TO_ASSUME_STAGING`
  - `aws-actions/configure-aws-credentials` v1 → v4

  **Pin all action SHAs across all workflows and composite actions:**
  - `actions/checkout` v2/v3 → v6.0.2
  - `actions/setup-node` v3 → v6.4.0
  - `actions/cache` v3 → v5
  - `actions/create-release` v1 → pinned
  - `aws-actions/configure-aws-credentials` v1 → v4
  - `styfle/cancel-workflow-action` 0.8.0 → 0.12.1
  - `mshick/add-pr-comment` v2 → pinned
  - `contributor-assistant/github-action` v2.2.0 → pinned
  - `mattallty/jest-github-action` v1.0.3 → pinned
  - `Maggi64/eslint-plus-action` master → pinned

  Part of [INFSEC-1135](https://linear.app/safe-global/issue/INFSEC-1135/migrate-github-actions-secrets-to-oidc).